### PR TITLE
Support nested arguments' variable references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Salesforce cache
 .sfdx/
+.sf/
 .localdevserver/
 
 # LWC VSCode autocomplete

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -390,6 +390,8 @@ This class is used for passing arguments to GraphQL nodes.
 
 `override String toString()` - Returns a string equivalent of the argument according to its value's type. For example, if the value is an instance of a class it will be serialized with JSON.
 
+`String toString(Boolean pretty)` - Returns a string equivalent of the argument according to its value's type. For example, if the value is an instance of a class it will be serialized with JSON. For object arguments will return prettified argument if the `pretty` param is true.
+
 `Boolean isVariable()` - Returns true if the value of the argument references a variable. Otherwise, returns false. The value is considered as a variable if it starts with the dollar `$` sign.
 
 ---

--- a/src/main/default/classes/nodes/arguments/GraphQLArgument.cls
+++ b/src/main/default/classes/nodes/arguments/GraphQLArgument.cls
@@ -1,8 +1,9 @@
 global class GraphQLArgument implements IGraphQLParser {
     // Searches for all JSON property names. Needed to escape properties' double quotes
     private static final String REPLACE_JSON_PROPS_REGEXP = '"(\\w+)"\\s*:';
-    // Takes the first match from the regex
-    private static final String ESCAPED_PROP_NAME_EXP = '$1:';
+    // Searches for all JSON values that are strings starting from '$'. Needed to escape variables' ref double quotes
+    private static final String REPLACE_JSON_VARIABLE_REFS_REGEXP = ':\\s*"(\\$\\w+)"';
+    private static final String FIRST_REGEX_MATCH_GROUP = '$1';
 
     private static final String DATE_VALUE_FORMAT = GraphQLConfigManager.getString(GraphQLConfig.DateArgumentFormat);
     private static final String DATE_TIME_VALUE_FORMAT = GraphQLConfigManager.getString(
@@ -34,6 +35,10 @@ global class GraphQLArgument implements IGraphQLParser {
     }
 
     global override String toString() {
+        return toString(false);
+    }
+
+    global String toString(Boolean pretty) {
         switch on type {
             when x_Integer, x_Float, x_Boolean, x_Null {
                 return String.valueOf(value);
@@ -54,14 +59,16 @@ global class GraphQLArgument implements IGraphQLParser {
                     GraphQLConstants.DOUBLE_QUOTES;
             }
             when else {
-                return JSON.serialize(value, SUPPRESS_NULLS)
-                    .replaceAll(REPLACE_JSON_PROPS_REGEXP, ESCAPED_PROP_NAME_EXP);
+                return objectToString(value, pretty);
             }
         }
     }
 
     public String parse(GraphQLBaseNode node, Boolean pretty) {
-        return key + GraphQLConstants.COLON + (pretty ? GraphQLConstants.SPACE : GraphQLConstants.EMPTY) + this;
+        return key +
+            GraphQLConstants.COLON +
+            (pretty ? GraphQLConstants.SPACE : GraphQLConstants.EMPTY) +
+            toString(pretty);
     }
 
     // There is no way to get an object's type yet
@@ -87,5 +94,25 @@ global class GraphQLArgument implements IGraphQLParser {
 
     private DateTime dateToDateTime(Date dateValue) {
         return DateTime.newInstance(dateValue.year(), dateValue.month(), dateValue.day());
+    }
+
+    private String objectToString(Object value, Boolean pretty) {
+        String jsonValue = pretty ? JSON.serializePretty(value, SUPPRESS_NULLS) : JSON.serialize(value, SUPPRESS_NULLS);
+
+        if (pretty) {
+            jsonValue = jsonValue
+                // Replace all multiple spaces with the single space. Couldn't use .normalizeSpace() because it would affect JSON string values as well
+                .replaceAll('\\s+"', GraphQLConstants.SPACE + GraphQLConstants.DOUBLE_QUOTES)
+                .replaceAll('\\s*}', GraphQLConstants.SPACE + GraphQLConstants.BRACE_RIGHT);
+        }
+
+        return jsonValue
+            .replaceAll(REPLACE_JSON_PROPS_REGEXP, FIRST_REGEX_MATCH_GROUP + GraphQLConstants.COLON)
+            .replaceAll(
+                REPLACE_JSON_VARIABLE_REFS_REGEXP,
+                GraphQLConstants.COLON +
+                (pretty ? GraphQLConstants.SPACE : GraphQLConstants.EMPTY) +
+                FIRST_REGEX_MATCH_GROUP
+            );
     }
 }

--- a/src/test/classes/GraphQLArgumentTest.cls
+++ b/src/test/classes/GraphQLArgumentTest.cls
@@ -161,12 +161,20 @@ private class GraphQLArgumentTest {
     @IsTest
     private static void stringifyObjectArgumentTest() {
         String key = 'key';
-        Map<String, Object> value = new Map<String, Object>{ 'key1' => 'value', 'key2' => 2 };
+        Map<String, Object> value = new Map<String, Object>{
+            'key1' => 'value',
+            'key2' => '$var',
+            'key3' => 2,
+            'key4' => new Map<String, Object>{ 'key41' => '$var2', 'key42' => 'value:"$var2"     !' }
+        };
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
         // Fields order is reversed
-        System.assertEquals('{key2:2,key1:"value"}', argument.toString());
+        System.assertEquals(
+            '{ key4: { key42: "value:\\"$var2\\"     !", key41: $var2 }, key3: 2, key2: $var, key1: "value" }',
+            argument.toString(true)
+        );
     }
 
     @IsTest

--- a/src/test/classes/GraphQLNodeTest.cls
+++ b/src/test/classes/GraphQLNodeTest.cls
@@ -320,7 +320,7 @@ private class GraphQLNodeTest {
         GraphQLNode node = new GraphQLNode(nodeName, fields)
             .withArgument('var1', 'test1')
             .withArgument('var2', 1)
-            .withArgument('var3', new Map<String, Object>{ 'f1' => 1, 'f2' => '2' });
+            .withArgument('var3', new Map<String, Object>{ 'f1' => 1, 'f2' => '2', 'f3' => '$ref' });
 
         GraphQLNode rootNode = new GraphQLNode('root').withNode(node);
 
@@ -329,11 +329,11 @@ private class GraphQLNodeTest {
         System.assertEquals(nodeName, node.name);
         System.assertEquals(fields.size(), node.nodes.size());
         System.assertEquals(
-            'root{testMethod(var1:"test1",var2:1,var3:{f2:"2",f1:1}){field1,field2,field3}}',
+            'root{testMethod(var1:"test1",var2:1,var3:{f3:$ref,f2:"2",f1:1}){field1,field2,field3}}',
             rootNode.build()
         );
         System.assertEquals(
-            'root {\n  testMethod(var1: "test1", var2: 1, var3: {f2:"2",f1:1}) {\n    field1\n    field2\n    field3\n  }\n}',
+            'root {\n  testMethod(var1: "test1", var2: 1, var3: { f3: $ref, f2: "2", f1: 1 }) {\n    field1\n    field2\n    field3\n  }\n}',
             rootNode.build(true)
         );
     }


### PR DESCRIPTION
### What does this PR do?

Fixes the issue due to which it's not possible to reference a variable inside the nested object argument.

### What issues does this PR fix or reference?

[Support for nested arguments a GraphQLNode](https://github.com/IlyaMatsuev/Apex-GraphQL-Client/issues/18)

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.  
[x] Code linting and formatting were performed.

### Functionality Before

This:

```java
GraphQLNode node = new GraphQLNode('test')
    .withArgument('arg', new Map<String, Object> { 'key1' => '$ref', 'key2' => 'some string' })l;
System.debug(node.build(true));
```

Would print:

```gql
test (arg:{key2:"some string",key1:"$ref"})
```

### Functionality After

This:

```java
GraphQLNode node = new GraphQLNode('test')
    .withArgument('arg', new Map<String, Object> { 'key1' => '$ref', 'key2' => 'some string' })l;
System.debug(node.build(true));
```

Would print:

```gql
test (arg: { key2: "some string", key1: $ref })
```
