### PR TITLE
Ability to use inline fragments

### DIFF
--- a/docs/examples/send-mutation.apex
+++ b/docs/examples/send-mutation.apex
@@ -15,7 +15,7 @@ GraphQLNode createCountryNode = new GraphQLNode('createCountry')
 
 GraphQLMutationNode mutation = new GraphQLMutationNode('CreateCountry', createCountryNode)
     // Define variable for the mutation
-    .withVariable('country', 'NewCountryInput!');
+    .defineVariable('country', 'NewCountryInput!');
 
 // Create our input object
 Country country = new Country();

--- a/docs/examples/send-query-with-directive.apex
+++ b/docs/examples/send-query-with-directive.apex
@@ -25,7 +25,7 @@ GraphQLNode citiesNode = new GraphQLNode('cities', new List<String> { 'id', 'nam
 
 GraphQLQueryNode query = new GraphQLQueryNode(new List<GraphQLNode> { countriesNode, citiesNode })
     // Define our $withCities variable. Note that it needs to be marked as required in order to use it in directives
-    .withVariable('withCities', 'Boolean!');
+    .defineVariable('withCities', 'Boolean!');
 
 GraphQLRequest request = query.asRequest()
     // Pass the $withCities variable value to the request

--- a/docs/examples/send-query-with-fragment.apex
+++ b/docs/examples/send-query-with-fragment.apex
@@ -32,7 +32,7 @@ GraphQLNode citiesNode = new GraphQLNode('cities')
 
 GraphQLQueryNode query = new GraphQLQueryNode(new List<GraphQLNode> { countriesNode, citiesNode })
     // Define fragment for the query
-    .withFragment(cityFieldsFragment);
+    .defineFragment(cityFieldsFragment);
 
 GraphQLRequest request = query.asRequest();
 

--- a/docs/examples/send-query-with-inline-fragment.apex
+++ b/docs/examples/send-query-with-inline-fragment.apex
@@ -1,0 +1,54 @@
+/*
+query CountriesQuery {
+  countries {
+    name
+    capital {
+      ... on City {
+        id
+        name
+      }
+    }
+  }
+}
+*/
+
+// Create fragment instance passing the type name it's referring to. If we don't provide fragment name it's evaluated as inline fragment
+private GraphQLFragmentNode cityFieldsFragment = new GraphQLFragmentNode('City').withField('id').withField('name');
+
+private GraphQLNode countriesNode = new GraphQLNode('countries')
+    .withField('name')
+    // Use inline fragment fields for the capital node
+    .withNode(new GraphQLNode('capital').withFragment(cityFieldsFragment));
+
+private GraphQLQueryNode query = new GraphQLQueryNode(new List<GraphQLNode> { countriesNode, citiesNode });
+
+private GraphQLRequest request = query.asRequest();
+
+private IGraphQLClient client = new GraphQLHttpClient('https://simple-gql-server.herokuapp.com/gql');
+
+private GraphQLResponse response = client.send(request);
+
+if (response.hasErrors()) {
+    System.debug('First error: ' + response.getErrors().get(0).message);
+} else {
+    // Handling response as you wish, same as in other examples
+    Map<String, Object> dataMap = response.getData();
+    DataWrapper data = (DataWrapper) response.getDataAs(DataWrapper.class);
+    List<Country> countries = (List<Country>) response.getDataNodeAs('countries', List<Country>.class);
+}
+
+// ***************************************** //
+
+public class DataWrapper {
+    public List<Country> countries;
+}
+
+public class Country {
+    public String name;
+    public City capital;
+}
+
+public class City {
+    public Integer id;
+    public String name;
+}

--- a/docs/examples/send-query-with-inline-fragment.apex
+++ b/docs/examples/send-query-with-inline-fragment.apex
@@ -18,7 +18,7 @@ private GraphQLFragmentNode cityFieldsFragment = new GraphQLFragmentNode('City')
 private GraphQLNode countriesNode = new GraphQLNode('countries')
     .withField('name')
     // Use inline fragment fields for the capital node
-    .withNode(new GraphQLNode('capital').withFragment(cityFieldsFragment));
+    .withNode(new GraphQLNode('capital').withInlineFragment(cityFieldsFragment));
 
 private GraphQLQueryNode query = new GraphQLQueryNode(new List<GraphQLNode> { countriesNode, citiesNode });
 

--- a/docs/examples/send-query.apex
+++ b/docs/examples/send-query.apex
@@ -25,7 +25,7 @@ GraphQLNode citiesNode = new GraphQLNode('cities')
 
 GraphQLQueryNode query = new GraphQLQueryNode('CountriesQuery', new List<GraphQLNode> { countriesNode, citiesNode })
     // Define variable for the query
-    .withVariable('limit', 'Int');
+    .defineVariable('limit', 'Int');
 
 GraphQLRequest request = query.asRequest()
     // You can add additional HTTP headers if you need

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -62,7 +62,7 @@ So, basically, in that case, this node can be used for a query request but the b
 
 `Map<String, GraphQLArgument> arguments` - The list of node's arguements mapped by their names. Read about [`GraphQLArgument` here](#graphqlargument). Arguments are optional.
 
-`Map<GraphQLDirectiveType, GraphQLDirective> directives` - The list of node's directives mapped by their types (`include` or `skip`). Read about [`GraphQLDirective` here](#graphqldirective). Directives are optional.
+`List<GraphQLDirective> directives` - The list of node's directives. Read about [`GraphQLDirective` here](#graphqldirective).
 
 ---
 
@@ -358,7 +358,7 @@ This class can be used for building fragments to make your queries look more eff
 
 `List<GraphQLBaseNode> nodes` - The list of child nodes of the current fragment. Includes inline fragments. If a node has no child nodes it'll be built as a field. The node can either be `GraphQLNode` or `GraphQLFragmentNode`.
 
----
+## `List<GraphQLDirective> directives` - The list of fragment's directives. Read about [`GraphQLDirective` here](#graphqldirective).
 
 ### Methods
 
@@ -371,6 +371,8 @@ This class can be used for building fragments to make your queries look more eff
 `Boolean hasNodes(GraphQLNode[] nodes)` - Returns true if there is at least one node from the provided array. Otherwise returns false.
 
 `Boolean hasNodes()` - Returns true if there is at least one child node in the current fragment. Otherwise returns false.
+
+`Boolean hasDirectives()` - Returns true if there is at least one directive for the current fragment. Otherwise returns false.
 
 `GraphQLFragmentNode withField(String field)` - Adds a new field to the fragment.
 
@@ -387,6 +389,14 @@ This class can be used for building fragments to make your queries look more eff
 `GraphQLFragmentNode withInlineFragment(GraphQLFragmentNode fragment)` - Adds a child fragment node with the set of fields for a particular type.
 
 `GraphQLFragmentNode withInlineFragments(GraphQLFragmentNode[] fragments)` - Adds child fragment nodes with the set of fields for particular types.
+
+`GraphQLFragmentNode includeIf(Boolean condition)` - Adds a new `include` directive to the current fragment. Accepts one parameter of type Boolean. Indicates whether the current fragment needs to be included in the response.
+
+`GraphQLFragmentNode includeIf(String variable)` - Adds a new `include` directive to the current fragment. Accepts one parameter of type String that represents the query variable name (can be passed with or without the `$` sign). Indicates whether the current fragment needs to be included in the response.
+
+`GraphQLFragmentNode skipIf(Boolean condition)` - Adds a new `skip` directive to the current fragment. Accepts one parameter of type Boolean. Indicates whether the current fragment needs to be skipped in the response.
+
+`GraphQLFragmentNode skipIf(String variable)` - Adds a new `skip` directive to the current fragment. Accepts one parameter of type String that represents the query variable name (can be passed with or without the `$` sign). Indicates whether the current fragment needs to be skipped in the response.
 
 `String build()` - Builds a non-formatted string representation of the fragment.
 

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -58,9 +58,7 @@ So, basically, in that case, this node can be used for a query request but the b
 
 `String alias` - Alias of the node. Null by default. You can read about node aliases [here](https://spec.graphql.org/June2018/#sec-Field-Alias).
 
-`List<GraphQLNode> nodes` - The list of child nodes (or fields) of the current node. If a node has no child nodes it'll be built as a field. Therefore, this property is optional.
-
-`List<GraphQLFragmentNode> fragments` - The list of child inline fragment nodes. The regular fragments are not stored here as they are pasted directly into node as child fields.
+`List<GraphQLBaseNode> nodes` - The list of child nodes of the current node. Includes inline fragments. If a node has no child nodes it'll be built as a field. The node can either be `GraphQLNode` or `GraphQLFragmentNode`.
 
 `Map<String, GraphQLArgument> arguments` - The list of node's arguements mapped by their names. Read about [`GraphQLArgument` here](#graphqlargument). Arguments are optional.
 
@@ -70,6 +68,10 @@ So, basically, in that case, this node can be used for a query request but the b
 
 ### Methods
 
+`Boolean isFieldNode()` - Returns true if the current node is an instance of `GraphQLNode`. Otherwise returns false.
+
+`Boolean isFragmentNode()` - Returns true if the current node is an instance of `GraphQLFragmentNode`. Otherwise returns false.
+
 `Boolean hasNode(GraphQLNode node)` - Returns true if there is a node with the same name from the parameter. Otherwise returns false.
 
 `Boolean hasNodes(GraphQLNode[] nodes)` - Returns true if there is at least one node from the provided array. Otherwise returns false.
@@ -77,8 +79,6 @@ So, basically, in that case, this node can be used for a query request but the b
 `Boolean hasNodes()` - Returns true if there is at least one child node in the current node. Otherwise returns false.
 
 `Boolean hasArguments()` - Returns true if there is at least one argument in the current node. Otherwise returns false.
-
-`Boolean hasInlineFragments()` - Returns true if there is at least one child inline fragment for the current node. Otherwise returns false.
 
 `Boolean hasDirectives()` - Returns true if there is at least one directive for the current node. Otherwise returns false.
 
@@ -118,11 +118,11 @@ So, basically, in that case, this node can be used for a query request but the b
 
 `String build(Boolean pretty)` - Builds a string representation of the current node. The result string can be formatted depending on the provided boolean flag `pretty`.
 
-`GraphQLQueryNode asQuery()` - Wraps the current node and returns a new instance of [`GraphQLQueryNode`](#graphqlquerynode) with the same node name and child nodes. Arguments are not passing to a new query node since they are not supported for the type [`GraphQLQueryNode`](#graphqlquerynode).
+`GraphQLQueryNode asQuery()` - Wraps the current node and returns a new instance of [`GraphQLQueryNode`](#graphqlquerynode) with the same node name and child nodes. Arguments and inline fragments are not passing to a new query node since they are not supported for the type [`GraphQLQueryNode`](#graphqlquerynode).
 
-`GraphQLMutationNode asMutation()` - Wraps the current node and returns a new instance of [`GraphQLMutationNode`](#graphqlmutationnode) with the same node name and child nodes. Arguments are not passing to a new mutation node since they are not supported for the type [`GraphQLMutationNode`](#graphqlmutationnode).
+`GraphQLMutationNode asMutation()` - Wraps the current node and returns a new instance of [`GraphQLMutationNode`](#graphqlmutationnode) with the same node name and child nodes. Arguments and inline fragments are not passing to a new mutation node since they are not supported for the type [`GraphQLMutationNode`](#graphqlmutationnode).
 
-`GraphQLSubscriptionNode asSubscription()` - Wraps the current node and returns a new instance of [`GraphQLSubscriptionNode`](#graphqlsubscriptionnode) with the same node name and child nodes. Arguments are not passing to a new query node since they are not supported for the type [`GraphQLSubscriptionNode`](#graphqlsubscriptionnode).
+`GraphQLSubscriptionNode asSubscription()` - Wraps the current node and returns a new instance of [`GraphQLSubscriptionNode`](#graphqlsubscriptionnode) with the same node name and child nodes. Arguments and inline fragments are not passing to a new query node since they are not supported for the type [`GraphQLSubscriptionNode`](#graphqlsubscriptionnode).
 
 ---
 
@@ -152,7 +152,7 @@ This class is only used for building queries.
 
 `String name` - The name of the query. Can be empty.
 
-`List<GraphQLNode> nodes` - The list of child nodes (or fields) of the current node. If a node has no child nodes it'll be built as a field. Therefore, this property is optional.
+`List<GraphQLBaseNode> nodes` - The list of child nodes of the current node. If a node has no child nodes it'll be built as a field.
 
 `List<GraphQLFragmentNode> fragments` - The list of fragment node definitions.
 
@@ -222,7 +222,7 @@ This class is only used for building mutations.
 
 `String name` - The name of the query. Can be empty.
 
-`List<GraphQLNode> nodes` - The list of child nodes (or fields) of the current node. If a node has no child nodes it'll be built as a field. Therefore, this property is optional.
+`List<GraphQLBaseNode> nodes` - The list of child nodes of the current node. If a node has no child nodes it'll be built as a field.
 
 `List<GraphQLFragmentNode> fragments` - The list of fragment node definitions.
 
@@ -292,7 +292,7 @@ This class is only used for building subscriptions. It's not possible yet to exe
 
 `String name` - The name of the query. Can be empty.
 
-`List<GraphQLNode> nodes` - The list of child nodes (or fields) of the current node. If a node has no child nodes it'll be built as a field. Therefore, this property is optional.
+`List<GraphQLBaseNode> nodes` - The list of child nodes of the current node. If a node has no child nodes it'll be built as a field.
 
 `List<GraphQLFragmentNode> fragments` - The list of fragment node definitions.
 
@@ -356,21 +356,21 @@ This class can be used for building fragments to make your queries look more eff
 
 `String type` - The name of the type the fragment describes fields for.
 
-`List<GraphQLNode> nodes` - The list of child nodes (or fields) of the fragment.
-
-`List<GraphQLFragmentNode> fragments` - The list of child inline fragment nodes. The regular fragments are not stored here as they are pasted directly into fragment as child fields.
+`List<GraphQLBaseNode> nodes` - The list of child nodes of the current fragment. Includes inline fragments. If a node has no child nodes it'll be built as a field. The node can either be `GraphQLNode` or `GraphQLFragmentNode`.
 
 ---
 
 ### Methods
+
+`Boolean isFieldNode()` - Returns true if the current node is an instance of `GraphQLNode`. Otherwise returns false.
+
+`Boolean isFragmentNode()` - Returns true if the current node is an instance of `GraphQLFragmentNode`. Otherwise returns false.
 
 `Boolean hasNode(GraphQLNode node)` - Returns true if there is a node with the same name from the parameter. Otherwise returns false.
 
 `Boolean hasNodes(GraphQLNode[] nodes)` - Returns true if there is at least one node from the provided array. Otherwise returns false.
 
 `Boolean hasNodes()` - Returns true if there is at least one child node in the current fragment. Otherwise returns false.
-
-`Boolean hasInlineFragments()` - Returns true if there is at least one child inline fragment for the current fragment. Otherwise returns false.
 
 `GraphQLFragmentNode withField(String field)` - Adds a new field to the fragment.
 

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -60,6 +60,8 @@ So, basically, in that case, this node can be used for a query request but the b
 
 `List<GraphQLNode> nodes` - The list of child nodes (or fields) of the current node. If a node has no child nodes it'll be built as a field. Therefore, this property is optional.
 
+`List<GraphQLFragmentNode> fragments` - The list of child inline fragment nodes. The regular fragments are not stored here as they are pasted directly into node as child fields.
+
 `Map<String, GraphQLArgument> arguments` - The list of node's arguements mapped by their names. Read about [`GraphQLArgument` here](#graphqlargument). Arguments are optional.
 
 `Map<GraphQLDirectiveType, GraphQLDirective> directives` - The list of node's directives mapped by their types (`include` or `skip`). Read about [`GraphQLDirective` here](#graphqldirective). Directives are optional.
@@ -76,6 +78,8 @@ So, basically, in that case, this node can be used for a query request but the b
 
 `Boolean hasArguments()` - Returns true if there is at least one argument in the current node. Otherwise returns false.
 
+`Boolean hasInlineFragments()` - Returns true if there is at least one child inline fragment for the current node. Otherwise returns false.
+
 `Boolean hasDirectives()` - Returns true if there is at least one directive for the current node. Otherwise returns false.
 
 `GraphQLNode byAlias(String alias)` - Adds an alias to the node, so, that the results in the GraphQL response can be accessed by that alias name. You can read about node aliases [here](https://spec.graphql.org/June2018/#sec-Field-Alias).
@@ -91,6 +95,10 @@ So, basically, in that case, this node can be used for a query request but the b
 `GraphQLNode withFragment(String fragmentName)` - Adds a reference to a fragment's fields. Accepts the fragment name.
 
 `GraphQLNode withFragments(String[] fragmentNames)` - Adds references to fragments' fields. Accepts the fragments' names.
+
+`GraphQLNode withInlineFragment(GraphQLFragmentNode fragment)` - Adds a child fragment node with the set of fields for a particular type.
+
+`GraphQLNode withInlineFragments(GraphQLFragmentNode[] fragments)` - Adds child fragment nodes with the set of fields for particular types.
 
 `GraphQLNode withArgument(String key, Object value)` - Adds a new argument for the current node. Accepts key and value as parameters. Value can be any type - it will be automatically converted to the appropriate GraphQL type. Returns the current node instance.
 
@@ -146,6 +154,8 @@ This class is only used for building queries.
 
 `List<GraphQLNode> nodes` - The list of child nodes (or fields) of the current node. If a node has no child nodes it'll be built as a field. Therefore, this property is optional.
 
+`List<GraphQLFragmentNode> fragments` - The list of fragment node definitions.
+
 `Map<String, String> variables` - Variable names mapped to their type definitions. E.g. `(varName: Int! = 1)`.
 
 ---
@@ -158,6 +168,8 @@ This class is only used for building queries.
 
 `Boolean hasNodes()` - Returns true if there is at least one child node in the current node. Otherwise returns false.
 
+`Boolean hasFragments()` - Returns true if there is at least one fragment definition in the query. Otherwise returns false.
+
 `Boolean hasVariables()` - Returns true if there is at least one variable in the query. Otherwise returns false.
 
 `GraphQLQueryNode withField(String field)` - Adds a new field to the current node. Returns the current node instance.
@@ -168,11 +180,11 @@ This class is only used for building queries.
 
 `GraphQLQueryNode withNodes(GraphQLNode[] nodes)` - Adds new child nodes to the current node. Accepts one parameter of type [`GraphQLNode[]`](#graphqlnode) (list can also be implicitly converted to the array). Returns the current node instance.
 
-`GraphQLQueryNode withFragment(GraphQLFragmentNode fragment)` - Defines a fragment for the query. Accepts the instance of the [`GraphQLFragmentNode`](#graphqlfragmentnode) class.
+`GraphQLQueryNode defineFragment(GraphQLFragmentNode fragment)` - Defines a fragment for the query. Accepts the instance of the [`GraphQLFragmentNode`](#graphqlfragmentnode) class.
 
-`GraphQLQueryNode withFragments(GraphQLFragmentNode[] fragments)` - Defines multiple fragments for the query. Accepts the array of the [`GraphQLFragmentNode`](#graphqlfragmentnode) instances.
+`GraphQLQueryNode defineFragments(GraphQLFragmentNode[] fragments)` - Defines multiple fragments for the query. Accepts the array of the [`GraphQLFragmentNode`](#graphqlfragmentnode) instances.
 
-`GraphQLQueryNode withVariable(String name, String typeDefinition)` - Defines a new variable for the query with the name provided as the first parameter (name is specified without a dollar `$` sign). The second parameter contains type definition of the variable as a string.
+`GraphQLQueryNode defineVariable(String name, String typeDefinition)` - Defines a new variable for the query with the name provided as the first parameter (name is specified without a dollar `$` sign). The second parameter contains type definition of the variable as a string.
 
 `GraphQLOperation getOperation()` - Returns the [`GraphQLOperation`](#graphqloperation) instance of the current node. In case of GraphQLQueryNode it's `Query`.
 
@@ -212,6 +224,8 @@ This class is only used for building mutations.
 
 `List<GraphQLNode> nodes` - The list of child nodes (or fields) of the current node. If a node has no child nodes it'll be built as a field. Therefore, this property is optional.
 
+`List<GraphQLFragmentNode> fragments` - The list of fragment node definitions.
+
 `Map<String, String> variables` - Variable names mapped to their type definitions. E.g. `(varName: Int! = 1)`.
 
 ---
@@ -224,6 +238,8 @@ This class is only used for building mutations.
 
 `Boolean hasNodes()` - Returns true if there is at least one child node in the current node. Otherwise returns false.
 
+`Boolean hasFragments()` - Returns true if there is at least one fragment definition in the mutation. Otherwise returns false.
+
 `Boolean hasVariables()` - Returns true if there is at least one variable in the query. Otherwise returns false.
 
 `GraphQLMutationNode withField(String field)` - Adds a new field to the current node. Returns the current node instance.
@@ -234,11 +250,11 @@ This class is only used for building mutations.
 
 `GraphQLMutationNode withNodes(GraphQLNode[] nodes)` - Adds new child nodes to the current node. Accepts one parameter of type [`GraphQLNode[]`](#graphqlnode) (list can also be implicitly converted to the array). Returns the current node instance.
 
-`GraphQLMutationNode withFragment(GraphQLFragmentNode fragment)` - Defines a fragment for the mutation. Accepts the instance of the [`GraphQLFragmentNode`](#graphqlfragmentnode) class.
+`GraphQLMutationNode defineFragment(GraphQLFragmentNode fragment)` - Defines a fragment for the mutation. Accepts the instance of the [`GraphQLFragmentNode`](#graphqlfragmentnode) class.
 
-`GraphQLMutationNode withFragments(GraphQLFragmentNode[] fragments)` - Defines multiple fragments for the mutation. Accepts the array of the [`GraphQLFragmentNode`](#graphqlfragmentnode) instances.
+`GraphQLMutationNode defineFragments(GraphQLFragmentNode[] fragments)` - Defines multiple fragments for the mutation. Accepts the array of the [`GraphQLFragmentNode`](#graphqlfragmentnode) instances.
 
-`GraphQLMutationNode withVariable(String name, String typeDefinition)` - Defines a new variable for the mutation with the name provided as the first parameter (name is specified without a dollar `$` sign). The second parameter contains type definition of the variable as a string.
+`GraphQLMutationNode defineVariable(String name, String typeDefinition)` - Defines a new variable for the mutation with the name provided as the first parameter (name is specified without a dollar `$` sign). The second parameter contains type definition of the variable as a string.
 
 `GraphQLOperation getOperation()` - Returns the [`GraphQLOperation`](#graphqloperation) instance of the current node. In case of GraphQLQueryNode it's `Mutation`.
 
@@ -278,6 +294,8 @@ This class is only used for building subscriptions. It's not possible yet to exe
 
 `List<GraphQLNode> nodes` - The list of child nodes (or fields) of the current node. If a node has no child nodes it'll be built as a field. Therefore, this property is optional.
 
+`List<GraphQLFragmentNode> fragments` - The list of fragment node definitions.
+
 `Map<String, String> variables` - Variable names mapped to their type definitions. E.g. `(varName: Int! = 1)`.
 
 ---
@@ -290,6 +308,8 @@ This class is only used for building subscriptions. It's not possible yet to exe
 
 `Boolean hasNodes()` - Returns true if there is at least one child node in the current node. Otherwise returns false.
 
+`Boolean hasFragments()` - Returns true if there is at least one fragment definition in the subscription. Otherwise returns false.
+
 `Boolean hasVariables()` - Returns true if there is at least one variable in the query. Otherwise returns false.
 
 `GraphQLSubscriptionNode withField(String field)` - Adds a new field to the current node. Returns the current node instance.
@@ -300,11 +320,11 @@ This class is only used for building subscriptions. It's not possible yet to exe
 
 `GraphQLSubscriptionNode withNodes(GraphQLNode[] nodes)` - Adds new child nodes to the current node. Accepts one parameter of type [`GraphQLNode[]`](#graphqlnode) (list can also be implicitly converted to the array). Returns the current node instance.
 
-`GraphQLSubscriptionNode withFragment(GraphQLFragmentNode fragment)` - Defines a fragment for the subscription. Accepts the instance of the [`GraphQLFragmentNode`](#graphqlfragmentnode) class.
+`GraphQLSubscriptionNode defineFragment(GraphQLFragmentNode fragment)` - Defines a fragment for the subscription. Accepts the instance of the [`GraphQLFragmentNode`](#graphqlfragmentnode) class.
 
-`GraphQLSubscriptionNode withFragments(GraphQLFragmentNode[] fragments)` - Defines multiple fragments for the subscription. Accepts the array of the [`GraphQLFragmentNode`](#graphqlfragmentnode) instances.
+`GraphQLSubscriptionNode defineFragments(GraphQLFragmentNode[] fragments)` - Defines multiple fragments for the subscription. Accepts the array of the [`GraphQLFragmentNode`](#graphqlfragmentnode) instances.
 
-`GraphQLSubscriptionNode withVariable(String name, String typeDefinition)` - Defines a new variable for the mutation with the name provided as the first parameter (name is specified without a dollar `$` sign). The second parameter contains type definition of the variable as a string.
+`GraphQLSubscriptionNode defineVariable(String name, String typeDefinition)` - Defines a new variable for the mutation with the name provided as the first parameter (name is specified without a dollar `$` sign). The second parameter contains type definition of the variable as a string.
 
 `GraphQLOperation getOperation()` - Returns the [`GraphQLOperation`](#graphqloperation) instance of the current node. In case of GraphQLQueryNode it's `Subscription`.
 
@@ -338,6 +358,8 @@ This class can be used for building fragments to make your queries look more eff
 
 `List<GraphQLNode> nodes` - The list of child nodes (or fields) of the fragment.
 
+`List<GraphQLFragmentNode> fragments` - The list of child inline fragment nodes. The regular fragments are not stored here as they are pasted directly into fragment as child fields.
+
 ---
 
 ### Methods
@@ -347,6 +369,8 @@ This class can be used for building fragments to make your queries look more eff
 `Boolean hasNodes(GraphQLNode[] nodes)` - Returns true if there is at least one node from the provided array. Otherwise returns false.
 
 `Boolean hasNodes()` - Returns true if there is at least one child node in the current fragment. Otherwise returns false.
+
+`Boolean hasInlineFragments()` - Returns true if there is at least one child inline fragment for the current fragment. Otherwise returns false.
 
 `GraphQLFragmentNode withField(String field)` - Adds a new field to the fragment.
 
@@ -359,6 +383,10 @@ This class can be used for building fragments to make your queries look more eff
 `GraphQLFragmentNode withFragment(String fragmentName)` - Adds a reference to another fragment's fields. Accepts the fragment name.
 
 `GraphQLFragmentNode withFragments(String[] fragmentNames)` - Adds reference to others fragments' fields. Accepts the fragments' names.
+
+`GraphQLFragmentNode withInlineFragment(GraphQLFragmentNode fragment)` - Adds a child fragment node with the set of fields for a particular type.
+
+`GraphQLFragmentNode withInlineFragments(GraphQLFragmentNode[] fragments)` - Adds child fragment nodes with the set of fields for particular types.
 
 `String build()` - Builds a non-formatted string representation of the fragment.
 

--- a/src/main/default/classes/nodes/GraphQLBaseNode.cls
+++ b/src/main/default/classes/nodes/GraphQLBaseNode.cls
@@ -12,6 +12,11 @@ global abstract class GraphQLBaseNode {
      */
     global final List<GraphQLNode> nodes = new List<GraphQLNode>();
 
+    /**
+     * @description The list of regular or inline fragments added to the node
+     */
+    global final List<GraphQLFragmentNode> fragments = new List<GraphQLFragmentNode>();
+
     protected GraphQLBaseNode(String name, List<String> fields) {
         this(name, new List<GraphQLNode>(), fields);
     }
@@ -108,5 +113,10 @@ global abstract class GraphQLBaseNode {
             fields.add(GraphQLConstants.DOT.repeat(3) + fragmentName);
         }
         return addFields(fields);
+    }
+
+    protected virtual GraphQLBaseNode addInlineFragments(List<GraphQLFragmentNode> fragments) {
+        this.fragments.addAll(fragments);
+        return this;
     }
 }

--- a/src/main/default/classes/nodes/GraphQLBaseNode.cls
+++ b/src/main/default/classes/nodes/GraphQLBaseNode.cls
@@ -12,6 +12,11 @@ global abstract class GraphQLBaseNode {
      */
     global final List<GraphQLBaseNode> nodes = new List<GraphQLBaseNode>();
 
+    /**
+     * @description The list of directives attached to the node
+     */
+    global final List<GraphQLDirective> directives = new List<GraphQLDirective>();
+
     protected GraphQLBaseNode(String name, List<String> fields) {
         this(name, new List<GraphQLNode>(), fields);
     }
@@ -79,6 +84,14 @@ global abstract class GraphQLBaseNode {
     }
 
     /**
+     * @description Check if the current node contains any directives
+     * @return `true` if there are any directives. `false` otherwise
+     */
+    global Boolean hasDirectives() {
+        return !directives.isEmpty();
+    }
+
+    /**
      * @description Parse the node as a string
      * @return String representation of the node
      */
@@ -133,6 +146,11 @@ global abstract class GraphQLBaseNode {
             }
         }
         nodes.addAll(fragments);
+        return this;
+    }
+
+    protected virtual GraphQLBaseNode addDirective(GraphQLDirective directive) {
+        directives.add(directive);
         return this;
     }
 

--- a/src/main/default/classes/nodes/GraphQLBaseNode.cls
+++ b/src/main/default/classes/nodes/GraphQLBaseNode.cls
@@ -10,12 +10,7 @@ global abstract class GraphQLBaseNode {
     /**
      * @description The list of child nodes
      */
-    global final List<GraphQLNode> nodes = new List<GraphQLNode>();
-
-    /**
-     * @description The list of regular or inline fragments added to the node
-     */
-    global final List<GraphQLFragmentNode> fragments = new List<GraphQLFragmentNode>();
+    global final List<GraphQLBaseNode> nodes = new List<GraphQLBaseNode>();
 
     protected GraphQLBaseNode(String name, List<String> fields) {
         this(name, new List<GraphQLNode>(), fields);
@@ -35,6 +30,22 @@ global abstract class GraphQLBaseNode {
     }
 
     /**
+     * @description Check if the current node is an instance of `GraphQLNode`
+     * @return `true` if the current instance is `GraphQLNode`
+     */
+    global Boolean isFieldNode() {
+        return this instanceof GraphQLNode;
+    }
+
+    /**
+     * @description Check if the current node is an instance of `GraphQLFragmentNode`
+     * @return `true` if the current instance is `GraphQLFragmentNode`
+     */
+    global Boolean isFragmentNode() {
+        return this instanceof GraphQLFragmentNode;
+    }
+
+    /**
      * @description Check if the provided node exists in the child nodes. Searches by the node's name
      * @param node The target GraphQL node to search for
      * @return `true` if the node with the same name is found in child nodes. `false` otherwise
@@ -49,7 +60,7 @@ global abstract class GraphQLBaseNode {
      * @return `true` if one of the nodes with the same name is found in child nodes. `false` otherwise
      */
     global virtual Boolean hasNodes(GraphQLNode[] nodes) {
-        for (GraphQLNode existingNode : this.nodes) {
+        for (GraphQLBaseNode existingNode : this.nodes) {
             for (GraphQLNode node : nodes) {
                 if (existingNode.name == node.name) {
                     return true;
@@ -116,7 +127,15 @@ global abstract class GraphQLBaseNode {
     }
 
     protected virtual GraphQLBaseNode addInlineFragments(GraphQLFragmentNode[] fragments) {
-        this.fragments.addAll(fragments);
+        for (GraphQLFragmentNode fragment : fragments) {
+            if (!fragment.isInline()) {
+                throw new GraphQLBaseNodeException('Not possible to add non-inline fragment: ' + fragment.name);
+            }
+        }
+        nodes.addAll(fragments);
         return this;
     }
+
+    @TestVisible
+    private class GraphQLBaseNodeException extends Exception {}
 }

--- a/src/main/default/classes/nodes/GraphQLBaseNode.cls
+++ b/src/main/default/classes/nodes/GraphQLBaseNode.cls
@@ -115,7 +115,7 @@ global abstract class GraphQLBaseNode {
         return addFields(fields);
     }
 
-    protected virtual GraphQLBaseNode addInlineFragments(List<GraphQLFragmentNode> fragments) {
+    protected virtual GraphQLBaseNode addInlineFragments(GraphQLFragmentNode[] fragments) {
         this.fragments.addAll(fragments);
         return this;
     }

--- a/src/main/default/classes/nodes/GraphQLNode.cls
+++ b/src/main/default/classes/nodes/GraphQLNode.cls
@@ -74,7 +74,7 @@ global class GraphQLNode extends GraphQLBaseNode {
 
     /**
      * @description Check if the current node contains any inline fragments
-     * @return `true` if there are no inline fragments. `false` otherwise
+     * @return `true` if there are any inline fragments. `false` otherwise
      */
     global Boolean hasInlineFragments() {
         return !fragments.isEmpty();

--- a/src/main/default/classes/nodes/GraphQLNode.cls
+++ b/src/main/default/classes/nodes/GraphQLNode.cls
@@ -287,5 +287,6 @@ global class GraphQLNode extends GraphQLBaseNode {
         return this;
     }
 
+    @TestVisible
     private class GraphQLNodeException extends Exception {}
 }

--- a/src/main/default/classes/nodes/GraphQLNode.cls
+++ b/src/main/default/classes/nodes/GraphQLNode.cls
@@ -73,14 +73,6 @@ global class GraphQLNode extends GraphQLBaseNode {
     }
 
     /**
-     * @description Check if the current node contains any inline fragments
-     * @return `true` if there are any inline fragments. `false` otherwise
-     */
-    global Boolean hasInlineFragments() {
-        return !fragments.isEmpty();
-    }
-
-    /**
      * @description Check if the current node contains any directives
      * @return `true` if there are any directives. `false` otherwise
      */
@@ -157,7 +149,7 @@ global class GraphQLNode extends GraphQLBaseNode {
      * @description Add an inline fragment to the current node
      * @param fragment The instance of the `GraphQLFragmentNode`. Should be inline fragment without a name
      * @return The current instance of `GraphQLNode`
-     * @throws GraphQLNodeException If the passed fragment is not inline
+     * @throws GraphQLBaseNodeException If the passed fragment is not inline
      */
     global GraphQLNode withInlineFragment(GraphQLFragmentNode fragment) {
         return withInlineFragments(new List<GraphQLFragmentNode> { fragment });
@@ -167,14 +159,9 @@ global class GraphQLNode extends GraphQLBaseNode {
      * @description Add inline fragments to the current node
      * @param fragment The instances of the `GraphQLFragmentNode`. Should be inline fragments without names
      * @return The current instance of `GraphQLNode`
-     * @throws GraphQLNodeException If some of the passed fragments are not inline
+     * @throws GraphQLBaseNodeException If some of the passed fragments are not inline
      */
     global GraphQLNode withInlineFragments(GraphQLFragmentNode[] fragments) {
-        for (GraphQLFragmentNode fragment : fragments) {
-            if (!fragment.isInline()) {
-                throw new GraphQLNodeException('Not possible to add non-inline fragments: ' + fragment.name);
-            }
-        }
         return (GraphQLNode) addInlineFragments(fragments);
     }
 
@@ -250,7 +237,7 @@ global class GraphQLNode extends GraphQLBaseNode {
      * @return The new `GraphQLQueryNode` instance
      */
     global GraphQLQueryNode asQuery() {
-        return new GraphQLQueryNode(this.name, this.nodes);
+        return new GraphQLQueryNode(name, getFieldNodes());
     }
 
     /**
@@ -258,7 +245,7 @@ global class GraphQLNode extends GraphQLBaseNode {
      * @return The new `GraphQLMutationNode` instance
      */
     global GraphQLMutationNode asMutation() {
-        return new GraphQLMutationNode(this.name, this.nodes);
+        return new GraphQLMutationNode(name, getFieldNodes());
     }
 
     /**
@@ -266,7 +253,7 @@ global class GraphQLNode extends GraphQLBaseNode {
      * @return The new `GraphQLSubscriptionNode` instance
      */
     global GraphQLSubscriptionNode asSubscription() {
-        return new GraphQLSubscriptionNode(this.name, this.nodes);
+        return new GraphQLSubscriptionNode(name, getFieldNodes());
     }
 
     /**
@@ -287,6 +274,13 @@ global class GraphQLNode extends GraphQLBaseNode {
         return this;
     }
 
-    @TestVisible
-    private class GraphQLNodeException extends Exception {}
+    private List<GraphQLNode> getFieldNodes() {
+        List<GraphQLNode> fieldNodes = new List<GraphQLNode>();
+        for (GraphQLBaseNode node : this.nodes) {
+            if (node.isFieldNode()) {
+                fieldNodes.add((GraphQLNode) node);
+            }
+        }
+        return fieldNodes;
+    }
 }

--- a/src/main/default/classes/nodes/GraphQLNode.cls
+++ b/src/main/default/classes/nodes/GraphQLNode.cls
@@ -18,6 +18,11 @@ global class GraphQLNode extends GraphQLBaseNode {
     global final Map<GraphQLDirectiveType, GraphQLDirective> directives = new Map<GraphQLDirectiveType, GraphQLDirective>();
 
     /**
+     * @description The list of inline fragments added to the node
+     */
+    global final List<GraphQLFragmentNode> inlineFragments = new List<GraphQLFragmentNode>();
+
+    /**
      * @description Create an instance of `GraphQLNode` with the empty name
      */
     global GraphQLNode() {
@@ -148,6 +153,32 @@ global class GraphQLNode extends GraphQLBaseNode {
     }
 
     /**
+     * @description Add an inline fragment to the current node
+     * @param fragment The inline fragment to add
+     * @throws GraphQLNodeException If the provided fragment is not inline
+     * @return The current instance of `GraphQLNode`
+     */
+    global GraphQLNode withInlineFragment(GraphQLFragmentNode fragment) {
+        return withInlineFragments(new List<String> { fragment });
+    }
+
+    /**
+     * @description Add multiple inline fragments to the current node
+     * @param fragments The list of inline fragments to add
+     * @throws GraphQLNodeException If one of the provided fragments is not inline
+     * @return The current instance of `GraphQLNode`
+     */
+    global GraphQLNode withInlineFragments(GraphQLFragmentNode[] fragments) {
+        for (GraphQLFragmentNode fragment : fragments) {
+            if (!fragment.isInline()) {
+                throw new GraphQLNodeException('The added fragments should be inline.');
+            }
+            inlineFragments.addAll(fragments);
+        }
+        return this;
+    }
+
+    /**
      * @description Add an argument to the current node
      * @param key The argument name
      * @param value The argument value. Use string with the `$` sign for variable referencing
@@ -255,4 +286,6 @@ global class GraphQLNode extends GraphQLBaseNode {
         this.directives.put(type, new GraphQLDirective(type, ifArgumentValue));
         return this;
     }
+
+    private class GraphQLNodeException extends Exception {}
 }

--- a/src/main/default/classes/nodes/GraphQLNode.cls
+++ b/src/main/default/classes/nodes/GraphQLNode.cls
@@ -13,11 +13,6 @@ global class GraphQLNode extends GraphQLBaseNode {
     global final Map<String, GraphQLArgument> arguments = new Map<String, GraphQLArgument>();
 
     /**
-     * @description The Map of node directives with the names as keys
-     */
-    global final Map<GraphQLDirectiveType, GraphQLDirective> directives = new Map<GraphQLDirectiveType, GraphQLDirective>();
-
-    /**
      * @description Create an instance of `GraphQLNode` with the empty name
      */
     global GraphQLNode() {
@@ -70,14 +65,6 @@ global class GraphQLNode extends GraphQLBaseNode {
      */
     global Boolean hasArguments() {
         return !arguments.isEmpty();
-    }
-
-    /**
-     * @description Check if the current node contains any directives
-     * @return `true` if there are any directives. `false` otherwise
-     */
-    global Boolean hasDirectives() {
-        return !directives.isEmpty();
     }
 
     /**
@@ -202,7 +189,7 @@ global class GraphQLNode extends GraphQLBaseNode {
      * @return The current instance of `GraphQLNode`
      */
     global GraphQLNode includeIf(Boolean condition) {
-        return withDirective(GraphQLDirectiveType.Include, condition);
+        return (GraphQLNode) addDirective(new GraphQLDirective(GraphQLDirectiveType.Include, condition));
     }
 
     /**
@@ -211,7 +198,7 @@ global class GraphQLNode extends GraphQLBaseNode {
      * @return The current instance of `GraphQLNode`
      */
     global GraphQLNode includeIf(String variable) {
-        return withDirective(GraphQLDirectiveType.Include, variable);
+        return (GraphQLNode) addDirective(new GraphQLDirective(GraphQLDirectiveType.Include, variable));
     }
 
     /**
@@ -220,7 +207,7 @@ global class GraphQLNode extends GraphQLBaseNode {
      * @return The current instance of `GraphQLNode`
      */
     global GraphQLNode skipIf(Boolean condition) {
-        return withDirective(GraphQLDirectiveType.Skip, condition);
+        return (GraphQLNode) addDirective(new GraphQLDirective(GraphQLDirectiveType.Skip, condition));
     }
 
     /**
@@ -229,7 +216,7 @@ global class GraphQLNode extends GraphQLBaseNode {
      * @return The current instance of `GraphQLNode`
      */
     global GraphQLNode skipIf(String variable) {
-        return withDirective(GraphQLDirectiveType.Skip, variable);
+        return (GraphQLNode) addDirective(new GraphQLDirective(GraphQLDirectiveType.Skip, variable));
     }
 
     /**
@@ -262,16 +249,6 @@ global class GraphQLNode extends GraphQLBaseNode {
      */
     global override IGraphQLParser getParser() {
         return new GraphQLNodeParser();
-    }
-
-    private GraphQLNode withDirective(GraphQLDirectiveType type, Boolean ifArgumentValue) {
-        this.directives.put(type, new GraphQLDirective(type, ifArgumentValue));
-        return this;
-    }
-
-    private GraphQLNode withDirective(GraphQLDirectiveType type, String ifArgumentValue) {
-        this.directives.put(type, new GraphQLDirective(type, ifArgumentValue));
-        return this;
     }
 
     private List<GraphQLNode> getFieldNodes() {

--- a/src/main/default/classes/nodes/GraphQLNode.cls
+++ b/src/main/default/classes/nodes/GraphQLNode.cls
@@ -17,12 +17,6 @@ global class GraphQLNode extends GraphQLBaseNode {
      */
     global final Map<GraphQLDirectiveType, GraphQLDirective> directives = new Map<GraphQLDirectiveType, GraphQLDirective>();
 
-    // TODO: Should be moved to GraphQLBaseNode (it will be used by regular nodes, operations and other fragments)
-    /**
-     * @description The list of fragments added to the node
-     */
-    global final List<GraphQLFragmentNode> fragments = new List<GraphQLFragmentNode>();
-
     /**
      * @description Create an instance of `GraphQLNode` with the empty name
      */
@@ -79,6 +73,14 @@ global class GraphQLNode extends GraphQLBaseNode {
     }
 
     /**
+     * @description Check if the current node contains any inline fragments
+     * @return `true` if there are no inline fragments. `false` otherwise
+     */
+    global Boolean hasInlineFragments() {
+        return !fragments.isEmpty();
+    }
+
+    /**
      * @description Check if the current node contains any directives
      * @return `true` if there are any directives. `false` otherwise
      */
@@ -130,8 +132,7 @@ global class GraphQLNode extends GraphQLBaseNode {
      * @return The current instance of `GraphQLNode`
      */
     global GraphQLNode withNodes(GraphQLNode[] nodes) {
-        addNodes(nodes);
-        return this;
+        return (GraphQLNode) addNodes(nodes);
     }
 
     /**
@@ -144,32 +145,37 @@ global class GraphQLNode extends GraphQLBaseNode {
     }
 
     /**
-     * @description Add a fragment the current node. For a regular fragment adds a name reference to the node
-     * @param fragment The instance of the `GraphQLFragmentNode`. Can be either regular or inline fragment
-     * @return The current instance of `GraphQLNode`
-     */
-    global GraphQLNode withFragment(GraphQLFragmentNode fragment) {
-        return withFragments(new List<GraphQLFragmentNode> { fragment });
-    }
-
-    /**
      * @description Add multiple fragment uses to the current node
      * @param fragmentNames The list of names of the fragments to be used
      * @return The current instance of `GraphQLNode`
      */
     global GraphQLNode withFragments(String[] fragmentNames) {
-        addFragments(fragmentNames);
-        return this;
+        return (GraphQLNode) addFragments(fragmentNames);
     }
 
     /**
-     * @description Add a fragment the current node. For a regular fragment adds a name reference to the node
-     * @param fragment The instance of the `GraphQLFragmentNode`. Can be either regular or inline fragment
+     * @description Add an inline fragment to the current node
+     * @param fragment The instance of the `GraphQLFragmentNode`. Should be inline fragment without a name
      * @return The current instance of `GraphQLNode`
+     * @throws GraphQLNodeException If the passed fragment is not inline
      */
-    global GraphQLNode withFragments(GraphQLFragmentNode[] fragments) {
-        // TODO
-        return this;
+    global GraphQLNode withInlineFragment(GraphQLFragmentNode fragment) {
+        return withInlineFragments(new List<GraphQLFragmentNode> { fragment });
+    }
+
+    /**
+     * @description Add inline fragments to the current node
+     * @param fragment The instances of the `GraphQLFragmentNode`. Should be inline fragments without names
+     * @return The current instance of `GraphQLNode`
+     * @throws GraphQLNodeException If some of the passed fragments are not inline
+     */
+    global GraphQLNode withInlineFragments(GraphQLFragmentNode[] fragments) {
+        for (GraphQLFragmentNode fragment : fragments) {
+            if (!fragment.isInline()) {
+                throw new GraphQLNodeException('Not possible to add non-inline fragments: ' + fragment.name);
+            }
+        }
+        return (GraphQLNode) addInlineFragments(fragments);
     }
 
     /**

--- a/src/main/default/classes/nodes/GraphQLNode.cls
+++ b/src/main/default/classes/nodes/GraphQLNode.cls
@@ -17,10 +17,11 @@ global class GraphQLNode extends GraphQLBaseNode {
      */
     global final Map<GraphQLDirectiveType, GraphQLDirective> directives = new Map<GraphQLDirectiveType, GraphQLDirective>();
 
+    // TODO: Should be moved to GraphQLBaseNode (it will be used by regular nodes, operations and other fragments)
     /**
-     * @description The list of inline fragments added to the node
+     * @description The list of fragments added to the node
      */
-    global final List<GraphQLFragmentNode> inlineFragments = new List<GraphQLFragmentNode>();
+    global final List<GraphQLFragmentNode> fragments = new List<GraphQLFragmentNode>();
 
     /**
      * @description Create an instance of `GraphQLNode` with the empty name
@@ -143,6 +144,15 @@ global class GraphQLNode extends GraphQLBaseNode {
     }
 
     /**
+     * @description Add a fragment the current node. For a regular fragment adds a name reference to the node
+     * @param fragment The instance of the `GraphQLFragmentNode`. Can be either regular or inline fragment
+     * @return The current instance of `GraphQLNode`
+     */
+    global GraphQLNode withFragment(GraphQLFragmentNode fragment) {
+        return withFragments(new List<GraphQLFragmentNode> { fragment });
+    }
+
+    /**
      * @description Add multiple fragment uses to the current node
      * @param fragmentNames The list of names of the fragments to be used
      * @return The current instance of `GraphQLNode`
@@ -153,28 +163,12 @@ global class GraphQLNode extends GraphQLBaseNode {
     }
 
     /**
-     * @description Add an inline fragment to the current node
-     * @param fragment The inline fragment to add
-     * @throws GraphQLNodeException If the provided fragment is not inline
+     * @description Add a fragment the current node. For a regular fragment adds a name reference to the node
+     * @param fragment The instance of the `GraphQLFragmentNode`. Can be either regular or inline fragment
      * @return The current instance of `GraphQLNode`
      */
-    global GraphQLNode withInlineFragment(GraphQLFragmentNode fragment) {
-        return withInlineFragments(new List<String> { fragment });
-    }
-
-    /**
-     * @description Add multiple inline fragments to the current node
-     * @param fragments The list of inline fragments to add
-     * @throws GraphQLNodeException If one of the provided fragments is not inline
-     * @return The current instance of `GraphQLNode`
-     */
-    global GraphQLNode withInlineFragments(GraphQLFragmentNode[] fragments) {
-        for (GraphQLFragmentNode fragment : fragments) {
-            if (!fragment.isInline()) {
-                throw new GraphQLNodeException('The added fragments should be inline.');
-            }
-            inlineFragments.addAll(fragments);
-        }
+    global GraphQLNode withFragments(GraphQLFragmentNode[] fragments) {
+        // TODO
         return this;
     }
 

--- a/src/main/default/classes/nodes/fragments/GraphQLFragmentNode.cls
+++ b/src/main/default/classes/nodes/fragments/GraphQLFragmentNode.cls
@@ -8,6 +8,14 @@ global class GraphQLFragmentNode extends GraphQLBaseNode {
     global final String type;
 
     /**
+     * @description Create an instance of an inline fragment by the provided type
+     * @param type The fragment referencing type
+     */
+    global GraphQLFragmentNode(String type) {
+        this(GraphQLConstants.EMPTY, type);
+    }
+
+    /**
      * @description Create an instance of a fragment by the provided name and type
      * @param name The fragment name
      * @param type The fragment referencing type
@@ -46,6 +54,14 @@ global class GraphQLFragmentNode extends GraphQLBaseNode {
     global GraphQLFragmentNode(String name, String type, List<GraphQLNode> nodes, List<String> fields) {
         super(name, nodes, fields);
         this.type = type;
+    }
+
+    /**
+     * @description Check if the current fragment is an inline fragment
+     * @return `true` if the fragment is inline. `false` otherwise
+     */
+    global Boolean isInline() {
+        return String.isBlank(name);
     }
 
     /**

--- a/src/main/default/classes/nodes/fragments/GraphQLFragmentNode.cls
+++ b/src/main/default/classes/nodes/fragments/GraphQLFragmentNode.cls
@@ -1,5 +1,5 @@
 /**
- * @description Represents a GraphQL fragment node definition
+ * @description Represents a GraphQL fragment node definition. Can be used for regular and inline fragments
  */
 global class GraphQLFragmentNode extends GraphQLBaseNode {
     /**
@@ -62,14 +62,6 @@ global class GraphQLFragmentNode extends GraphQLBaseNode {
      */
     global Boolean isInline() {
         return String.isBlank(name);
-    }
-
-    /**
-     * @description Check if the current fragment contains any child inline fragments
-     * @return `true` if there are any inline fragments. `false` otherwise
-     */
-    global Boolean hasInlineFragments() {
-        return !fragments.isEmpty();
     }
 
     /**
@@ -141,7 +133,7 @@ global class GraphQLFragmentNode extends GraphQLBaseNode {
      * @description Add an inline fragment to the current fragment
      * @param fragment The instance of the `GraphQLFragmentNode`. Should be inline fragment without a name
      * @return The current instance of `GraphQLFragmentNode`
-     * @throws GraphQLFragmentNodeException If the passed fragment is not inline
+     * @throws GraphQLBaseNodeException If the passed fragment is not inline
      */
     global GraphQLFragmentNode withInlineFragment(GraphQLFragmentNode fragment) {
         return withInlineFragments(new List<GraphQLFragmentNode> { fragment });
@@ -151,16 +143,9 @@ global class GraphQLFragmentNode extends GraphQLBaseNode {
      * @description Add inline fragments to the current fragment
      * @param fragment The instances of the `GraphQLFragmentNode`. Should be inline fragments without names
      * @return The current instance of `GraphQLFragmentNode`
-     * @throws GraphQLFragmentNodeException If some of the passed fragments are not inline
+     * @throws GraphQLBaseNodeException If some of the passed fragments are not inline
      */
     global GraphQLFragmentNode withInlineFragments(GraphQLFragmentNode[] fragments) {
-        for (GraphQLFragmentNode fragment : fragments) {
-            if (!fragment.isInline()) {
-                throw new GraphQLFragmentNodeException('Not possible to add non-inline fragments: ' + fragment.name);
-            }
-        }
         return (GraphQLFragmentNode) addInlineFragments(fragments);
     }
-
-    private class GraphQLFragmentNodeException extends Exception {}
 }

--- a/src/main/default/classes/nodes/fragments/GraphQLFragmentNode.cls
+++ b/src/main/default/classes/nodes/fragments/GraphQLFragmentNode.cls
@@ -65,6 +65,14 @@ global class GraphQLFragmentNode extends GraphQLBaseNode {
     }
 
     /**
+     * @description Check if the current fragment contains any child inline fragments
+     * @return `true` if there are any inline fragments. `false` otherwise
+     */
+    global Boolean hasInlineFragments() {
+        return !fragments.isEmpty();
+    }
+
+    /**
      * @description Add a field to the current fragment
      * @param field The field name to be added
      * @return The current instance of `GraphQLFragmentNode`
@@ -128,4 +136,31 @@ global class GraphQLFragmentNode extends GraphQLBaseNode {
     global override IGraphQLParser getParser() {
         return new GraphQLFragmentNodeParser();
     }
+
+    /**
+     * @description Add an inline fragment to the current fragment
+     * @param fragment The instance of the `GraphQLFragmentNode`. Should be inline fragment without a name
+     * @return The current instance of `GraphQLFragmentNode`
+     * @throws GraphQLFragmentNodeException If the passed fragment is not inline
+     */
+    global GraphQLFragmentNode withInlineFragment(GraphQLFragmentNode fragment) {
+        return withInlineFragments(new List<GraphQLFragmentNode> { fragment });
+    }
+
+    /**
+     * @description Add inline fragments to the current fragment
+     * @param fragment The instances of the `GraphQLFragmentNode`. Should be inline fragments without names
+     * @return The current instance of `GraphQLFragmentNode`
+     * @throws GraphQLFragmentNodeException If some of the passed fragments are not inline
+     */
+    global GraphQLFragmentNode withInlineFragments(GraphQLFragmentNode[] fragments) {
+        for (GraphQLFragmentNode fragment : fragments) {
+            if (!fragment.isInline()) {
+                throw new GraphQLFragmentNodeException('Not possible to add non-inline fragments: ' + fragment.name);
+            }
+        }
+        return (GraphQLFragmentNode) addInlineFragments(fragments);
+    }
+
+    private class GraphQLFragmentNodeException extends Exception {}
 }

--- a/src/main/default/classes/nodes/fragments/GraphQLFragmentNode.cls
+++ b/src/main/default/classes/nodes/fragments/GraphQLFragmentNode.cls
@@ -8,6 +8,13 @@ global class GraphQLFragmentNode extends GraphQLBaseNode {
     global final String type;
 
     /**
+     * @description Create an instance of an inline fragment not providing the type. Assuming the type is identical to the parent node's type
+     */
+    global GraphQLFragmentNode() {
+        this(GraphQLConstants.EMPTY);
+    }
+
+    /**
      * @description Create an instance of an inline fragment by the provided type
      * @param type The fragment referencing type
      */
@@ -147,5 +154,41 @@ global class GraphQLFragmentNode extends GraphQLBaseNode {
      */
     global GraphQLFragmentNode withInlineFragments(GraphQLFragmentNode[] fragments) {
         return (GraphQLFragmentNode) addInlineFragments(fragments);
+    }
+
+    /**
+     * @description Add the standard `includeIf` directive to the current fragment
+     * @param condition The boolean condition for the directive
+     * @return The current instance of `GraphQLFragmentNode`
+     */
+    global GraphQLFragmentNode includeIf(Boolean condition) {
+        return (GraphQLFragmentNode) addDirective(new GraphQLDirective(GraphQLDirectiveType.Include, condition));
+    }
+
+    /**
+     * @description Add the standard `includeIf` directive to the current fragment
+     * @param variable The variable reference for the directive. The `$` sign is not required
+     * @return The current instance of `GraphQLFragmentNode`
+     */
+    global GraphQLFragmentNode includeIf(String variable) {
+        return (GraphQLFragmentNode) addDirective(new GraphQLDirective(GraphQLDirectiveType.Include, variable));
+    }
+
+    /**
+     * @description Add the standard `skipIf` directive to the current fragment
+     * @param condition The boolean condition for the directive
+     * @return The current instance of `GraphQLFragmentNode`
+     */
+    global GraphQLFragmentNode skipIf(Boolean condition) {
+        return (GraphQLFragmentNode) addDirective(new GraphQLDirective(GraphQLDirectiveType.Skip, condition));
+    }
+
+    /**
+     * @description Add the standard `skipIf` directive to the current fragment
+     * @param variable The variable reference for the directive. The `$` sign is not required
+     * @return The current instance of `GraphQLFragmentNode`
+     */
+    global GraphQLFragmentNode skipIf(String variable) {
+        return (GraphQLFragmentNode) addDirective(new GraphQLDirective(GraphQLDirectiveType.Skip, variable));
     }
 }

--- a/src/main/default/classes/nodes/operations/GraphQLOperationNode.cls
+++ b/src/main/default/classes/nodes/operations/GraphQLOperationNode.cls
@@ -7,6 +7,11 @@ global abstract class GraphQLOperationNode extends GraphQLBaseNode {
      */
     global final Map<String, String> variables = new Map<String, String>();
 
+    /**
+     * @description The list of fragment definitions added to the operation
+     */
+    global final List<GraphQLFragmentNode> fragments = new List<GraphQLFragmentNode>();
+
     protected GraphQLOperationNode(String alias, List<String> fields) {
         super(alias, fields);
     }

--- a/src/main/default/classes/nodes/operations/GraphQLOperationNode.cls
+++ b/src/main/default/classes/nodes/operations/GraphQLOperationNode.cls
@@ -7,11 +7,6 @@ global abstract class GraphQLOperationNode extends GraphQLBaseNode {
      */
     global final Map<String, String> variables = new Map<String, String>();
 
-    /**
-     * @description The list of defined fragments for the operation
-     */
-    global final List<GraphQLFragmentNode> fragments = new List<GraphQLFragmentNode>();
-
     protected GraphQLOperationNode(String alias, List<String> fields) {
         super(alias, fields);
     }
@@ -62,7 +57,7 @@ global abstract class GraphQLOperationNode extends GraphQLBaseNode {
         for (GraphQLFragmentNode fragment : fragments) {
             if (fragment.isInline()) {
                 throw new GraphQLOperationNodeException(
-                    'It\'s not allowed to put inline fragments to the operation node'
+                    'Not possible to add an inline fragment to the operation node: ' + fragment.name
                 );
             }
             this.fragments.add(fragment);

--- a/src/main/default/classes/nodes/operations/GraphQLOperationNode.cls
+++ b/src/main/default/classes/nodes/operations/GraphQLOperationNode.cls
@@ -59,7 +59,14 @@ global abstract class GraphQLOperationNode extends GraphQLBaseNode {
     global abstract GraphQLOperation getOperation();
 
     protected GraphQLOperationNode addFragments(List<GraphQLFragmentNode> fragments) {
-        this.fragments.addAll(fragments);
+        for (GraphQLFragmentNode fragment : fragments) {
+            if (fragment.isInline()) {
+                throw new GraphQLOperationNodeException(
+                    'It\'s not allowed to put inline fragments to the operation node'
+                );
+            }
+            this.fragments.add(fragment);
+        }
         return this;
     }
 

--- a/src/main/default/classes/nodes/operations/mutation/GraphQLMutationNode.cls
+++ b/src/main/default/classes/nodes/operations/mutation/GraphQLMutationNode.cls
@@ -109,6 +109,7 @@ global class GraphQLMutationNode extends GraphQLOperationNode {
     /**
      * @description Add a fragment definition for the current mutation node
      * @param fragment The fragment definition to add
+     * @throws GraphQLOperationNodeException If the provided fragment is inline
      * @return The instance of the current `GraphQLMutationNode` class
      */
     global GraphQLMutationNode withFragment(GraphQLFragmentNode fragment) {
@@ -118,6 +119,7 @@ global class GraphQLMutationNode extends GraphQLOperationNode {
     /**
      * @description Add multiple fragment definitions for the current mutation node
      * @param fragments The list of fragment definitions to add
+     * @throws GraphQLOperationNodeException If the provided fragments are inline
      * @return The instance of the current `GraphQLMutationNode` class
      */
     global GraphQLMutationNode withFragments(GraphQLFragmentNode[] fragments) {

--- a/src/main/default/classes/nodes/operations/mutation/GraphQLMutationNode.cls
+++ b/src/main/default/classes/nodes/operations/mutation/GraphQLMutationNode.cls
@@ -83,8 +83,7 @@ global class GraphQLMutationNode extends GraphQLOperationNode {
      * @return The instance of the current `GraphQLMutationNode` class
      */
     global GraphQLMutationNode withFields(String[] fields) {
-        addFields(fields);
-        return this;
+        return (GraphQLMutationNode) addFields(fields);
     }
 
     /**
@@ -102,8 +101,7 @@ global class GraphQLMutationNode extends GraphQLOperationNode {
      * @return The instance of the current `GraphQLMutationNode` class
      */
     global GraphQLMutationNode withNodes(GraphQLNode[] nodes) {
-        addNodes(nodes);
-        return this;
+        return (GraphQLMutationNode) addNodes(nodes);
     }
 
     /**
@@ -112,19 +110,18 @@ global class GraphQLMutationNode extends GraphQLOperationNode {
      * @throws GraphQLOperationNodeException If the provided fragment is inline
      * @return The instance of the current `GraphQLMutationNode` class
      */
-    global GraphQLMutationNode withFragment(GraphQLFragmentNode fragment) {
-        return withFragments(new List<GraphQLFragmentNode> { fragment });
+    global GraphQLMutationNode defineFragment(GraphQLFragmentNode fragment) {
+        return defineFragments(new List<GraphQLFragmentNode> { fragment });
     }
 
     /**
      * @description Add multiple fragment definitions for the current mutation node
      * @param fragments The list of fragment definitions to add
-     * @throws GraphQLOperationNodeException If the provided fragments are inline
+     * @throws GraphQLOperationNodeException If some of the provided fragments are inline
      * @return The instance of the current `GraphQLMutationNode` class
      */
-    global GraphQLMutationNode withFragments(GraphQLFragmentNode[] fragments) {
-        addFragments(fragments);
-        return this;
+    global GraphQLMutationNode defineFragments(GraphQLFragmentNode[] fragments) {
+        return (GraphQLMutationNode) addFragments(fragments);
     }
 
     /**
@@ -133,9 +130,8 @@ global class GraphQLMutationNode extends GraphQLOperationNode {
      * @param typeDefinition The variable type definition
      * @return The instance of the current `GraphQLMutationNode` class
      */
-    global GraphQLMutationNode withVariable(String name, String typeDefinition) {
-        addVariable(name, typeDefinition);
-        return this;
+    global GraphQLMutationNode defineVariable(String name, String typeDefinition) {
+        return (GraphQLMutationNode) addVariable(name, typeDefinition);
     }
 
     /**

--- a/src/main/default/classes/nodes/operations/query/GraphQLQueryNode.cls
+++ b/src/main/default/classes/nodes/operations/query/GraphQLQueryNode.cls
@@ -83,8 +83,7 @@ global class GraphQLQueryNode extends GraphQLOperationNode {
      * @return The instance of the current `GraphQLQueryNode` class
      */
     global GraphQLQueryNode withFields(String[] fields) {
-        addFields(fields);
-        return this;
+        return (GraphQLQueryNode) addFields(fields);
     }
 
     /**
@@ -102,8 +101,7 @@ global class GraphQLQueryNode extends GraphQLOperationNode {
      * @return The instance of the current `GraphQLQueryNode` class
      */
     global GraphQLQueryNode withNodes(GraphQLNode[] nodes) {
-        addNodes(nodes);
-        return this;
+        return (GraphQLQueryNode) addNodes(nodes);
     }
 
     /**
@@ -112,19 +110,18 @@ global class GraphQLQueryNode extends GraphQLOperationNode {
      * @throws GraphQLOperationNodeException If the provided fragment is inline
      * @return The instance of the current `GraphQLQueryNode` class
      */
-    global GraphQLQueryNode withFragment(GraphQLFragmentNode fragment) {
-        return withFragments(new List<GraphQLFragmentNode> { fragment });
+    global GraphQLQueryNode defineFragment(GraphQLFragmentNode fragment) {
+        return defineFragments(new List<GraphQLFragmentNode> { fragment });
     }
 
     /**
      * @description Add multiple fragment definitions for the current query node
      * @param fragments The list of fragment definitions to add
-     * @throws GraphQLOperationNodeException If the provided fragments are inline
+     * @throws GraphQLOperationNodeException If some of the provided fragments are inline
      * @return The instance of the current `GraphQLQueryNode` class
      */
-    global GraphQLQueryNode withFragments(GraphQLFragmentNode[] fragments) {
-        addFragments(fragments);
-        return this;
+    global GraphQLQueryNode defineFragments(GraphQLFragmentNode[] fragments) {
+        return (GraphQLQueryNode) addFragments(fragments);
     }
 
     /**
@@ -133,9 +130,8 @@ global class GraphQLQueryNode extends GraphQLOperationNode {
      * @param typeDefinition The variable type definition
      * @return The instance of the current `GraphQLQueryNode` class
      */
-    global GraphQLQueryNode withVariable(String name, String typeDefinition) {
-        addVariable(name, typeDefinition);
-        return this;
+    global GraphQLQueryNode defineVariable(String name, String typeDefinition) {
+        return (GraphQLQueryNode) addVariable(name, typeDefinition);
     }
 
     /**

--- a/src/main/default/classes/nodes/operations/query/GraphQLQueryNode.cls
+++ b/src/main/default/classes/nodes/operations/query/GraphQLQueryNode.cls
@@ -109,6 +109,7 @@ global class GraphQLQueryNode extends GraphQLOperationNode {
     /**
      * @description Add a fragment definition for the current query node
      * @param fragment The fragment definition to add
+     * @throws GraphQLOperationNodeException If the provided fragment is inline
      * @return The instance of the current `GraphQLQueryNode` class
      */
     global GraphQLQueryNode withFragment(GraphQLFragmentNode fragment) {
@@ -118,6 +119,7 @@ global class GraphQLQueryNode extends GraphQLOperationNode {
     /**
      * @description Add multiple fragment definitions for the current query node
      * @param fragments The list of fragment definitions to add
+     * @throws GraphQLOperationNodeException If the provided fragments are inline
      * @return The instance of the current `GraphQLQueryNode` class
      */
     global GraphQLQueryNode withFragments(GraphQLFragmentNode[] fragments) {

--- a/src/main/default/classes/nodes/operations/subscription/GraphQLSubscriptionNode.cls
+++ b/src/main/default/classes/nodes/operations/subscription/GraphQLSubscriptionNode.cls
@@ -109,6 +109,7 @@ global class GraphQLSubscriptionNode extends GraphQLOperationNode {
     /**
      * @description Add a fragment definition for the current subscription node
      * @param fragment The fragment definition to add
+     * @throws GraphQLOperationNodeException If the provided fragment is inline
      * @return The instance of the current `GraphQLSubscriptionNode` class
      */
     global GraphQLSubscriptionNode withFragment(GraphQLFragmentNode fragment) {
@@ -118,6 +119,7 @@ global class GraphQLSubscriptionNode extends GraphQLOperationNode {
     /**
      * @description Add multiple fragment definitions for the current subscription node
      * @param fragments The list of fragment definitions to add
+     * @throws GraphQLOperationNodeException If the provided fragments are inline
      * @return The instance of the current `GraphQLSubscriptionNode` class
      */
     global GraphQLSubscriptionNode withFragments(GraphQLFragmentNode[] fragments) {

--- a/src/main/default/classes/nodes/operations/subscription/GraphQLSubscriptionNode.cls
+++ b/src/main/default/classes/nodes/operations/subscription/GraphQLSubscriptionNode.cls
@@ -83,8 +83,7 @@ global class GraphQLSubscriptionNode extends GraphQLOperationNode {
      * @return The instance of the current `GraphQLSubscriptionNode` class
      */
     global GraphQLSubscriptionNode withFields(String[] fields) {
-        addFields(fields);
-        return this;
+        return (GraphQLSubscriptionNode) addFields(fields);
     }
 
     /**
@@ -102,8 +101,7 @@ global class GraphQLSubscriptionNode extends GraphQLOperationNode {
      * @return The instance of the current `GraphQLSubscriptionNode` class
      */
     global GraphQLSubscriptionNode withNodes(GraphQLNode[] nodes) {
-        addNodes(nodes);
-        return this;
+        return (GraphQLSubscriptionNode) addNodes(nodes);
     }
 
     /**
@@ -112,19 +110,18 @@ global class GraphQLSubscriptionNode extends GraphQLOperationNode {
      * @throws GraphQLOperationNodeException If the provided fragment is inline
      * @return The instance of the current `GraphQLSubscriptionNode` class
      */
-    global GraphQLSubscriptionNode withFragment(GraphQLFragmentNode fragment) {
-        return withFragments(new List<GraphQLFragmentNode> { fragment });
+    global GraphQLSubscriptionNode defineFragment(GraphQLFragmentNode fragment) {
+        return defineFragments(new List<GraphQLFragmentNode> { fragment });
     }
 
     /**
      * @description Add multiple fragment definitions for the current subscription node
      * @param fragments The list of fragment definitions to add
-     * @throws GraphQLOperationNodeException If the provided fragments are inline
+     * @throws GraphQLOperationNodeException If some of the provided fragments are inline
      * @return The instance of the current `GraphQLSubscriptionNode` class
      */
-    global GraphQLSubscriptionNode withFragments(GraphQLFragmentNode[] fragments) {
-        addFragments(fragments);
-        return this;
+    global GraphQLSubscriptionNode defineFragments(GraphQLFragmentNode[] fragments) {
+        return (GraphQLSubscriptionNode) addFragments(fragments);
     }
 
     /**
@@ -133,9 +130,8 @@ global class GraphQLSubscriptionNode extends GraphQLOperationNode {
      * @param typeDefinition The variable type definition
      * @return The instance of the current `GraphQLSubscriptionNode` class
      */
-    global GraphQLSubscriptionNode withVariable(String name, String typeDefinition) {
-        addVariable(name, typeDefinition);
-        return this;
+    global GraphQLSubscriptionNode defineVariable(String name, String typeDefinition) {
+        return (GraphQLSubscriptionNode) addVariable(name, typeDefinition);
     }
 
     /**

--- a/src/main/default/classes/parsers/GraphQLFragmentNodeParser.cls
+++ b/src/main/default/classes/parsers/GraphQLFragmentNodeParser.cls
@@ -7,6 +7,24 @@ public class GraphQLFragmentNodeParser extends GraphQLParser {
     }
 
     private String parse(GraphQLFragmentNode fragment, Integer depth, Boolean pretty) {
+        if (fragment.isInline()) {
+            return parseInlineFragment(fragment, depth, pretty);
+        }
+        return parseFragmentDefinition(fragment, depth, pretty);
+    }
+
+    private String parseInlineFragment(GraphQLFragmentNode fragment, Integer depth, Boolean pretty) {
+        return getIndent(depth, pretty) +
+            GraphQLConstants.DOT.repeat(3) +
+            GraphQLConstants.SPACE +
+            ON_TYPE_KEYWORD +
+            GraphQLConstants.SPACE +
+            fragment.type +
+            getSmallIndent(pretty) +
+            parseChildNodes(fragment, depth, pretty);
+    }
+
+    private String parseFragmentDefinition(GraphQLFragmentNode fragment, Integer depth, Boolean pretty) {
         return FRAGMENT_KEYWORD +
             GraphQLConstants.SPACE +
             fragment.name +

--- a/src/main/default/classes/parsers/GraphQLFragmentNodeParser.cls
+++ b/src/main/default/classes/parsers/GraphQLFragmentNodeParser.cls
@@ -14,12 +14,13 @@ public class GraphQLFragmentNodeParser extends GraphQLParser {
     }
 
     private String parseInlineFragment(GraphQLFragmentNode fragment, Integer depth, Boolean pretty) {
+        String spread = GraphQLConstants.DOT.repeat(3);
+        if (String.isNotBlank(fragment.type)) {
+            spread += GraphQLConstants.SPACE + ON_TYPE_KEYWORD + GraphQLConstants.SPACE + fragment.type;
+        }
         return getIndent(depth, pretty) +
-            GraphQLConstants.DOT.repeat(3) +
-            GraphQLConstants.SPACE +
-            ON_TYPE_KEYWORD +
-            GraphQLConstants.SPACE +
-            fragment.type +
+            spread +
+            parseDirectives(fragment, pretty) +
             getSmallIndent(pretty) +
             parseChildNodes(fragment, depth, pretty);
     }
@@ -32,6 +33,7 @@ public class GraphQLFragmentNodeParser extends GraphQLParser {
             ON_TYPE_KEYWORD +
             GraphQLConstants.SPACE +
             fragment.type +
+            parseDirectives(fragment, pretty) +
             parseChildNodes(fragment, depth, pretty);
     }
 }

--- a/src/main/default/classes/parsers/GraphQLNodeParser.cls
+++ b/src/main/default/classes/parsers/GraphQLNodeParser.cls
@@ -1,6 +1,6 @@
 public class GraphQLNodeParser extends GraphQLParser {
     public override String parse(GraphQLBaseNode node, Integer depth, Boolean pretty) {
-        if (String.isBlank(node.name) && !node.hasNodes()) {
+        if (String.isBlank(node.name) && !node.hasNodes() && node.fragments.isEmpty()) {
             throw new GraphQLNodeParserException('Cannot parse an empty node without any child nodes');
         }
         return parseNode((GraphQLNode) node, depth, pretty);

--- a/src/main/default/classes/parsers/GraphQLNodeParser.cls
+++ b/src/main/default/classes/parsers/GraphQLNodeParser.cls
@@ -1,6 +1,6 @@
 public class GraphQLNodeParser extends GraphQLParser {
     public override String parse(GraphQLBaseNode node, Integer depth, Boolean pretty) {
-        if (String.isBlank(node.name) && !node.hasNodes() && node.fragments.isEmpty()) {
+        if (String.isBlank(node.name) && !node.hasNodes()) {
             throw new GraphQLNodeParserException('Cannot parse an empty node without any child nodes');
         }
         return parseNode((GraphQLNode) node, depth, pretty);

--- a/src/main/default/classes/parsers/GraphQLOperationNodeParser.cls
+++ b/src/main/default/classes/parsers/GraphQLOperationNodeParser.cls
@@ -6,9 +6,9 @@ public class GraphQLOperationNodeParser extends GraphQLParser {
     private String parse(GraphQLOperationNode node, Integer depth, Boolean pretty) {
         return parseOperation(node) +
             parseName(node, pretty) +
-            parseVariables(node, pretty) +
+            parseVariableDefinitions(node, pretty) +
             parseChildNodes(node, depth, pretty) +
-            parseFragments(node, depth, pretty);
+            parseFragmentDefinitions(node, depth, pretty);
     }
 
     private String parseOperation(GraphQLOperationNode node) {
@@ -19,7 +19,7 @@ public class GraphQLOperationNodeParser extends GraphQLParser {
         return String.isBlank(node.name) ? getSmallIndent(pretty) : (GraphQLConstants.SPACE + node.name);
     }
 
-    private String parseVariables(GraphQLOperationNode node, Boolean pretty) {
+    private String parseVariableDefinitions(GraphQLOperationNode node, Boolean pretty) {
         if (!node.hasVariables()) {
             return GraphQLConstants.EMPTY;
         }
@@ -41,7 +41,7 @@ public class GraphQLOperationNodeParser extends GraphQLParser {
             getSmallIndent(pretty);
     }
 
-    private String parseFragments(GraphQLOperationNode node, Integer depth, Boolean pretty) {
+    private String parseFragmentDefinitions(GraphQLOperationNode node, Integer depth, Boolean pretty) {
         if (!node.hasFragments()) {
             return GraphQLConstants.EMPTY;
         }

--- a/src/main/default/classes/parsers/GraphQLParser.cls
+++ b/src/main/default/classes/parsers/GraphQLParser.cls
@@ -22,7 +22,7 @@ public abstract class GraphQLParser implements IGraphQLParser {
     }
 
     protected String parseChildNodes(GraphQLBaseNode node, Integer depth, Boolean pretty) {
-        if (!node.hasNodes()) {
+        if (node.nodes.isEmpty() && node.fragments.isEmpty()) {
             return GraphQLConstants.EMPTY;
         }
 
@@ -38,6 +38,15 @@ public abstract class GraphQLParser implements IGraphQLParser {
         List<String> rawNodes = new List<String>();
         for (GraphQLNode n : node.nodes) {
             rawNodes.add(parseNode(n, depth + 1, pretty));
+        }
+        // TODO: Refactor the parsing strategy
+        for (GraphQLFragmentNode fragment : node.fragments) {
+            if (fragment.isInline()) {
+                rawNodes.add(
+                    ((GraphQLFragmentNodeParser) fragment.getParser())
+                        .parse((GraphQLBaseNode) fragment, depth + 1, pretty)
+                );
+            }
         }
 
         childNodes += String.join(rawNodes, pretty ? GraphQLConstants.LINE_BREAK : GraphQLConstants.COMMA);

--- a/src/main/default/classes/parsers/GraphQLParser.cls
+++ b/src/main/default/classes/parsers/GraphQLParser.cls
@@ -22,7 +22,7 @@ public abstract class GraphQLParser implements IGraphQLParser {
     }
 
     protected String parseChildNodes(GraphQLBaseNode node, Integer depth, Boolean pretty) {
-        if (node.nodes.isEmpty() && node.fragments.isEmpty()) {
+        if (!node.hasNodes()) {
             return GraphQLConstants.EMPTY;
         }
 
@@ -36,17 +36,8 @@ public abstract class GraphQLParser implements IGraphQLParser {
         childNodes += pretty ? GraphQLConstants.LINE_BREAK : GraphQLConstants.EMPTY;
 
         List<String> rawNodes = new List<String>();
-        for (GraphQLNode n : node.nodes) {
-            rawNodes.add(parseNode(n, depth + 1, pretty));
-        }
-        // TODO: Refactor the parsing strategy
-        for (GraphQLFragmentNode fragment : node.fragments) {
-            if (fragment.isInline()) {
-                rawNodes.add(
-                    ((GraphQLFragmentNodeParser) fragment.getParser())
-                        .parse((GraphQLBaseNode) fragment, depth + 1, pretty)
-                );
-            }
+        for (GraphQLBaseNode n : node.nodes) {
+            rawNodes.add(((GraphQLParser) n.getParser()).parse(n, depth + 1, pretty));
         }
 
         childNodes += String.join(rawNodes, pretty ? GraphQLConstants.LINE_BREAK : GraphQLConstants.COMMA);

--- a/src/main/default/classes/parsers/GraphQLParser.cls
+++ b/src/main/default/classes/parsers/GraphQLParser.cls
@@ -51,6 +51,19 @@ public abstract class GraphQLParser implements IGraphQLParser {
         return childNodes;
     }
 
+    protected String parseDirectives(GraphQLBaseNode node, Boolean pretty) {
+        if (!node.hasDirectives()) {
+            return GraphQLConstants.EMPTY;
+        }
+
+        List<String> rawDirectives = new List<String>();
+        for (GraphQLDirective directive : node.directives) {
+            rawDirectives.add(directive.parse(node, pretty));
+        }
+
+        return GraphQLConstants.SPACE + String.join(rawDirectives, GraphQLConstants.SPACE);
+    }
+
     protected String getIndent(Integer depth, Boolean pretty) {
         if (!pretty) {
             return GraphQLConstants.EMPTY;
@@ -86,19 +99,6 @@ public abstract class GraphQLParser implements IGraphQLParser {
         return GraphQLConstants.PARENTHESE_LEFT +
             String.join(rawArguments, GraphQLConstants.COMMA + getSmallIndent(pretty)) +
             GraphQLConstants.PARENTHESE_RIGHT;
-    }
-
-    private String parseDirectives(GraphQLNode node, Boolean pretty) {
-        if (!node.hasDirectives()) {
-            return GraphQLConstants.EMPTY;
-        }
-
-        List<String> rawDirectives = new List<String>();
-        for (GraphQLDirective directive : node.directives.values()) {
-            rawDirectives.add(directive.parse(node, pretty));
-        }
-
-        return GraphQLConstants.SPACE + String.join(rawDirectives, GraphQLConstants.SPACE);
     }
 
     private class GraphQLBaseParserException extends Exception {}

--- a/src/test/classes/GraphQLFragmentNodeTest.cls
+++ b/src/test/classes/GraphQLFragmentNodeTest.cls
@@ -96,21 +96,25 @@ private class GraphQLFragmentNodeTest {
     }
 
     @IsTest
-    private static void fragmentWithDirectiveTest() {
+    private static void fragmentWithDirectivesTest() {
         String name = 'Fields';
         String type = 'SomeType';
         GraphQLFragmentNode fragment = new GraphQLFragmentNode(name, type)
             .withField('field1')
             .withField('field2')
-            .includeIf(true);
+            .includeIf(true)
+            .skipIf(false);
 
         System.assert(fragment.hasNodes());
         System.assert(fragment.hasDirectives());
         System.assertEquals(2, fragment.nodes.size());
-        System.assertEquals(1, fragment.directives.size());
-        System.assertEquals('fragment Fields on SomeType @include(if:true){field1,field2}', fragment.build());
+        System.assertEquals(2, fragment.directives.size());
         System.assertEquals(
-            'fragment Fields on SomeType @include(if: true) {\n  field1\n  field2\n}',
+            'fragment Fields on SomeType @include(if:true) @skip(if:false){field1,field2}',
+            fragment.build()
+        );
+        System.assertEquals(
+            'fragment Fields on SomeType @include(if: true) @skip(if: false) {\n  field1\n  field2\n}',
             fragment.build(true)
         );
     }
@@ -136,14 +140,14 @@ private class GraphQLFragmentNodeTest {
             .withFields(new List<String> { 'field1', 'field2' })
             .withNode(new GraphQLNode('node', new List<String> { 'field1', 'field2' }))
             .withInlineFragment(new GraphQLFragmentNode('SomeType2').withField('field11'))
-            .withInlineFragment(new GraphQLFragmentNode().includeIf('var').withField('field22'));
+            .withInlineFragment(new GraphQLFragmentNode().includeIf('var').skipIf('var2').withField('field22'));
 
         System.assertEquals(
-            'fragment Fields on SomeType{field1,field2,node{field1,field2},... on SomeType2{field11},... @include(if:$var){field22}}',
+            'fragment Fields on SomeType{field1,field2,node{field1,field2},... on SomeType2{field11},... @include(if:$var) @skip(if:$var2){field22}}',
             fragment.build()
         );
         System.assertEquals(
-            'fragment Fields on SomeType {\n  field1\n  field2\n  node {\n    field1\n    field2\n  }\n  ... on SomeType2 {\n    field11\n  }\n  ... @include(if: $var) {\n    field22\n  }\n}',
+            'fragment Fields on SomeType {\n  field1\n  field2\n  node {\n    field1\n    field2\n  }\n  ... on SomeType2 {\n    field11\n  }\n  ... @include(if: $var) @skip(if: $var2) {\n    field22\n  }\n}',
             fragment.build(true)
         );
     }

--- a/src/test/classes/GraphQLFragmentNodeTest.cls
+++ b/src/test/classes/GraphQLFragmentNodeTest.cls
@@ -6,6 +6,7 @@ private class GraphQLFragmentNodeTest {
         String type = 'SomeType';
         GraphQLFragmentNode fragment = new GraphQLFragmentNode(name, type);
 
+        System.assert(fragment.isFragmentNode());
         System.assertEquals(name, fragment.name);
         System.assertEquals(type, fragment.type);
         System.assert(!fragment.hasNodes());
@@ -99,9 +100,8 @@ private class GraphQLFragmentNodeTest {
         GraphQLFragmentNode inlineFragment = new GraphQLFragmentNode('SomeType2').withField('field1');
         GraphQLFragmentNode fragment = new GraphQLFragmentNode('Fields', 'SomeType').withInlineFragment(inlineFragment);
 
-        System.assert(!fragment.hasNodes());
-        System.assert(fragment.hasInlineFragments());
-        System.assertEquals(1, fragment.fragments.size());
+        System.assert(fragment.hasNodes());
+        System.assertEquals(1, fragment.nodes.size());
     }
 
     /**

--- a/src/test/classes/GraphQLFragmentNodeTest.cls
+++ b/src/test/classes/GraphQLFragmentNodeTest.cls
@@ -96,6 +96,26 @@ private class GraphQLFragmentNodeTest {
     }
 
     @IsTest
+    private static void fragmentWithDirectiveTest() {
+        String name = 'Fields';
+        String type = 'SomeType';
+        GraphQLFragmentNode fragment = new GraphQLFragmentNode(name, type)
+            .withField('field1')
+            .withField('field2')
+            .includeIf(true);
+
+        System.assert(fragment.hasNodes());
+        System.assert(fragment.hasDirectives());
+        System.assertEquals(2, fragment.nodes.size());
+        System.assertEquals(1, fragment.directives.size());
+        System.assertEquals('fragment Fields on SomeType @include(if:true){field1,field2}', fragment.build());
+        System.assertEquals(
+            'fragment Fields on SomeType @include(if: true) {\n  field1\n  field2\n}',
+            fragment.build(true)
+        );
+    }
+
+    @IsTest
     private static void fragmentWithInlineFragmentTest() {
         GraphQLFragmentNode inlineFragment = new GraphQLFragmentNode('SomeType2').withField('field1');
         GraphQLFragmentNode fragment = new GraphQLFragmentNode('Fields', 'SomeType').withInlineFragment(inlineFragment);
@@ -115,14 +135,15 @@ private class GraphQLFragmentNodeTest {
         GraphQLFragmentNode fragment = new GraphQLFragmentNode(name, type)
             .withFields(new List<String> { 'field1', 'field2' })
             .withNode(new GraphQLNode('node', new List<String> { 'field1', 'field2' }))
-            .withInlineFragment(new GraphQLFragmentNode('SomeType2').withField('field11'));
+            .withInlineFragment(new GraphQLFragmentNode('SomeType2').withField('field11'))
+            .withInlineFragment(new GraphQLFragmentNode().includeIf('var').withField('field22'));
 
         System.assertEquals(
-            'fragment Fields on SomeType{field1,field2,node{field1,field2},... on SomeType2{field11}}',
+            'fragment Fields on SomeType{field1,field2,node{field1,field2},... on SomeType2{field11},... @include(if:$var){field22}}',
             fragment.build()
         );
         System.assertEquals(
-            'fragment Fields on SomeType {\n  field1\n  field2\n  node {\n    field1\n    field2\n  }\n  ... on SomeType2 {\n    field11\n  }\n}',
+            'fragment Fields on SomeType {\n  field1\n  field2\n  node {\n    field1\n    field2\n  }\n  ... on SomeType2 {\n    field11\n  }\n  ... @include(if: $var) {\n    field22\n  }\n}',
             fragment.build(true)
         );
     }

--- a/src/test/classes/GraphQLFragmentNodeTest.cls
+++ b/src/test/classes/GraphQLFragmentNodeTest.cls
@@ -58,7 +58,7 @@ private class GraphQLFragmentNodeTest {
     }
 
     @IsTest
-    private static void emptyFragmentWithFieldTest() {
+    private static void fragmentWithFieldTest() {
         String name = 'Fields';
         String type = 'SomeType';
         GraphQLFragmentNode fragment = new GraphQLFragmentNode(name, type).withField('field1');
@@ -70,7 +70,7 @@ private class GraphQLFragmentNodeTest {
     }
 
     @IsTest
-    private static void emptyFragmentWithNodeTest() {
+    private static void fragmentWithNodeTest() {
         String name = 'Fields';
         String type = 'SomeType';
         GraphQLFragmentNode fragment = new GraphQLFragmentNode(name, type)
@@ -83,7 +83,7 @@ private class GraphQLFragmentNodeTest {
     }
 
     @IsTest
-    private static void emptyFragmentWithFragmentTest() {
+    private static void fragmentWithFragmentTest() {
         String name = 'Fields';
         String type = 'SomeType';
         GraphQLFragmentNode fragment = new GraphQLFragmentNode(name, type).withFragment('OtherFields');
@@ -92,6 +92,16 @@ private class GraphQLFragmentNodeTest {
         System.assertEquals(type, fragment.type);
         System.assert(fragment.hasNodes());
         System.assertEquals(1, fragment.nodes.size());
+    }
+
+    @IsTest
+    private static void fragmentWithInlineFragmentTest() {
+        GraphQLFragmentNode inlineFragment = new GraphQLFragmentNode('SomeType2').withField('field1');
+        GraphQLFragmentNode fragment = new GraphQLFragmentNode('Fields', 'SomeType').withInlineFragment(inlineFragment);
+
+        System.assert(!fragment.hasNodes());
+        System.assert(fragment.hasInlineFragments());
+        System.assertEquals(1, fragment.fragments.size());
     }
 
     /**
@@ -104,11 +114,15 @@ private class GraphQLFragmentNodeTest {
         String type = 'SomeType';
         GraphQLFragmentNode fragment = new GraphQLFragmentNode(name, type)
             .withFields(new List<String> { 'field1', 'field2' })
-            .withNode(new GraphQLNode('node', new List<String> { 'field1', 'field2' }));
+            .withNode(new GraphQLNode('node', new List<String> { 'field1', 'field2' }))
+            .withInlineFragment(new GraphQLFragmentNode('SomeType2').withField('field11'));
 
-        System.assertEquals('fragment Fields on SomeType{field1,field2,node{field1,field2}}', fragment.build());
         System.assertEquals(
-            'fragment Fields on SomeType {\n  field1\n  field2\n  node {\n    field1\n    field2\n  }\n}',
+            'fragment Fields on SomeType{field1,field2,node{field1,field2},... on SomeType2{field11}}',
+            fragment.build()
+        );
+        System.assertEquals(
+            'fragment Fields on SomeType {\n  field1\n  field2\n  node {\n    field1\n    field2\n  }\n  ... on SomeType2 {\n    field11\n  }\n}',
             fragment.build(true)
         );
     }

--- a/src/test/classes/GraphQLMutationNodeTest.cls
+++ b/src/test/classes/GraphQLMutationNodeTest.cls
@@ -102,10 +102,10 @@ private class GraphQLMutationNodeTest {
     }
 
     @IsTest
-    private static void mutationWithFragmentTest() {
+    private static void mutationWithFragmentDefinitionTest() {
         GraphQLFragmentNode fragment = new GraphQLFragmentNode('fragment1', 'Type1');
 
-        GraphQLMutationNode node = new GraphQLMutationNode().withFragment(fragment);
+        GraphQLMutationNode node = new GraphQLMutationNode().defineFragment(fragment);
 
         System.assert(node.hasFragments());
         System.assertEquals(1, node.fragments.size());
@@ -113,13 +113,13 @@ private class GraphQLMutationNodeTest {
     }
 
     @IsTest
-    private static void mutationWithFragmentsTest() {
+    private static void mutationWithFragmentDefinitionsTest() {
         List<GraphQLFragmentNode> fragments = new List<GraphQLFragmentNode> {
             new GraphQLFragmentNode('fragment1', 'Type1'),
             new GraphQLFragmentNode('fragment2', 'Type2')
         };
 
-        GraphQLMutationNode node = new GraphQLMutationNode().withFragments(fragments);
+        GraphQLMutationNode node = new GraphQLMutationNode().defineFragments(fragments);
 
         System.assert(node.hasFragments());
         System.assertEquals(fragments.size(), node.fragments.size());
@@ -149,10 +149,10 @@ private class GraphQLMutationNodeTest {
     }
 
     @IsTest
-    private static void mutationWithVariableTest() {
+    private static void mutationWithVariableDefinitionTest() {
         GraphQLMutationNode node = new GraphQLMutationNode()
             .withNode(new GraphQLNode('node'))
-            .withVariable('var', '[String!]');
+            .defineVariable('var', '[String!]');
 
         System.assertEquals(1, node.variables.size());
     }
@@ -189,14 +189,14 @@ private class GraphQLMutationNodeTest {
     }
 
     @IsTest
-    private static void buildMutationWithVariablePositiveTest() {
+    private static void buildMutationWithVariableDefinitionPositiveTest() {
         List<GraphQLNode> nodes = new List<GraphQLNode> { new GraphQLNode('node1'), new GraphQLNode('node2') };
         List<String> fields = new List<String> { 'field3', 'field4' };
 
         GraphQLMutationNode mutation = new GraphQLMutationNode()
             .withNodes(nodes)
             .withFields(fields)
-            .withVariable('model', 'InputType!');
+            .defineVariable('model', 'InputType!');
 
         System.assert(mutation != null);
         System.assert(String.isBlank(mutation.name));

--- a/src/test/classes/GraphQLNodeTest.cls
+++ b/src/test/classes/GraphQLNodeTest.cls
@@ -136,6 +136,16 @@ private class GraphQLNodeTest {
     }
 
     @IsTest
+    private static void nodeWithInlineFragmentOnTheSameTypeTest() {
+        GraphQLNode node = new GraphQLNode()
+            .withInlineFragment(new GraphQLFragmentNode().withField('field1').withField('field2'));
+
+        System.assertEquals(1, node.nodes.size());
+        System.assertEquals('{...{field1,field2}}', node.build());
+        System.assertEquals('{\n  ... {\n    field1\n    field2\n  }\n}', node.build(true));
+    }
+
+    @IsTest
     private static void nodeWithInlineFragmentWithNamedFragmentNegativeTest() {
         GraphQLFragmentNode fragment = new GraphQLFragmentNode('fragment1', 'SomeType').withField('field1');
 
@@ -198,7 +208,7 @@ private class GraphQLNodeTest {
         GraphQLNode node = new GraphQLNode().includeIf(false).includeIf('var');
 
         System.assert(node.hasDirectives());
-        System.assertEquals(1, node.directives.size());
+        System.assertEquals(2, node.directives.size());
     }
 
     @IsTest
@@ -206,7 +216,7 @@ private class GraphQLNodeTest {
         GraphQLNode node = new GraphQLNode().skipIf(false).skipIf('var');
 
         System.assert(node.hasDirectives());
-        System.assertEquals(1, node.directives.size());
+        System.assertEquals(2, node.directives.size());
     }
 
     @IsTest

--- a/src/test/classes/GraphQLNodeTest.cls
+++ b/src/test/classes/GraphQLNodeTest.cls
@@ -111,6 +111,49 @@ private class GraphQLNodeTest {
     }
 
     @IsTest
+    private static void nodeWithInlineFragmentTest() {
+        GraphQLFragmentNode fragment = new GraphQLFragmentNode('SomeType').withField('field1');
+
+        GraphQLNode node = new GraphQLNode().withInlineFragment(fragment);
+
+        System.assert(node.nodes.isEmpty());
+        System.assert(node.hasInlineFragments());
+        System.assertEquals(1, node.fragments.size());
+        System.assertEquals('{... on SomeType{field1}}', node.build());
+        System.assertEquals('{\n  ... on SomeType {\n    field1\n  }\n}', node.build(true));
+    }
+
+    @IsTest
+    private static void nodeWithInlineFragmentsTest() {
+        List<GraphQLFragmentNode> fragments = new List<GraphQLFragmentNode> {
+            new GraphQLFragmentNode('SomeType').withField('field1'),
+            new GraphQLFragmentNode('SomeType2').withField('field11')
+        };
+
+        GraphQLNode node = new GraphQLNode().withInlineFragments(fragments);
+
+        System.assert(node.nodes.isEmpty());
+        System.assert(node.hasInlineFragments());
+        System.assertEquals(2, node.fragments.size());
+        System.assertEquals('{... on SomeType{field1},... on SomeType2{field11}}', node.build());
+    }
+
+    @IsTest
+    private static void nodeWithInlineFragmentWithNamedFragmentNegativeTest() {
+        GraphQLFragmentNode fragment = new GraphQLFragmentNode('fragment1', 'SomeType').withField('field1');
+
+        Exception error;
+        try {
+            new GraphQLNode().withInlineFragment(fragment);
+        } catch (Exception ex) {
+            error = ex;
+        }
+
+        System.assert(error != null);
+        System.assert(error instanceof GraphQLNode.GraphQLNodeException);
+    }
+
+    @IsTest
     private static void nodeWithNodeTest() {
         String nodeName = 'node1';
 
@@ -231,6 +274,22 @@ private class GraphQLNodeTest {
         System.assertEquals(fields.size() + 1, node.nodes.size());
         System.assertEquals('{field1,field2,field3,...SomeFields}', node.build());
         System.assertEquals('{\n  field1\n  field2\n  field3\n  ...SomeFields\n}', node.build(true));
+    }
+
+    @IsTest
+    private static void buildNodeWithInlineFragmentPositiveTest() {
+        GraphQLFragmentNode inlineFragment = new GraphQLFragmentNode('SomeType').withField('field11');
+
+        GraphQLNode node = new GraphQLNode()
+            .withField('field1')
+            .withFragment('SomeFields')
+            .withInlineFragment(inlineFragment);
+
+        System.assert(node != null);
+        System.assertEquals(2, node.nodes.size());
+        System.assertEquals(1, node.fragments.size());
+        System.assertEquals('{field1,...SomeFields,... on SomeType{field11}}', node.build());
+        System.assertEquals('{\n  field1\n  ...SomeFields\n  ... on SomeType {\n    field11\n  }\n}', node.build(true));
     }
 
     @IsTest

--- a/src/test/classes/GraphQLNodeTest.cls
+++ b/src/test/classes/GraphQLNodeTest.cls
@@ -4,6 +4,7 @@ private class GraphQLNodeTest {
     private static void emptyNodeTest() {
         GraphQLNode node = new GraphQLNode();
 
+        System.assert(node.isFieldNode());
         System.assertEquals(GraphQLConstants.EMPTY, node.name);
         System.assertEquals(0, node.nodes.size());
         System.assertEquals(0, node.arguments.size());
@@ -116,9 +117,7 @@ private class GraphQLNodeTest {
 
         GraphQLNode node = new GraphQLNode().withInlineFragment(fragment);
 
-        System.assert(node.nodes.isEmpty());
-        System.assert(node.hasInlineFragments());
-        System.assertEquals(1, node.fragments.size());
+        System.assertEquals(1, node.nodes.size());
         System.assertEquals('{... on SomeType{field1}}', node.build());
         System.assertEquals('{\n  ... on SomeType {\n    field1\n  }\n}', node.build(true));
     }
@@ -132,9 +131,7 @@ private class GraphQLNodeTest {
 
         GraphQLNode node = new GraphQLNode().withInlineFragments(fragments);
 
-        System.assert(node.nodes.isEmpty());
-        System.assert(node.hasInlineFragments());
-        System.assertEquals(2, node.fragments.size());
+        System.assertEquals(2, node.nodes.size());
         System.assertEquals('{... on SomeType{field1},... on SomeType2{field11}}', node.build());
     }
 
@@ -150,7 +147,7 @@ private class GraphQLNodeTest {
         }
 
         System.assert(error != null);
-        System.assert(error instanceof GraphQLNode.GraphQLNodeException);
+        System.assert(error instanceof GraphQLBaseNode.GraphQLBaseNodeException);
     }
 
     @IsTest
@@ -286,8 +283,7 @@ private class GraphQLNodeTest {
             .withInlineFragment(inlineFragment);
 
         System.assert(node != null);
-        System.assertEquals(2, node.nodes.size());
-        System.assertEquals(1, node.fragments.size());
+        System.assertEquals(3, node.nodes.size());
         System.assertEquals('{field1,...SomeFields,... on SomeType{field11}}', node.build());
         System.assertEquals('{\n  field1\n  ...SomeFields\n  ... on SomeType {\n    field11\n  }\n}', node.build(true));
     }

--- a/src/test/classes/GraphQLQueryNodeTest.cls
+++ b/src/test/classes/GraphQLQueryNodeTest.cls
@@ -102,10 +102,10 @@ private class GraphQLQueryNodeTest {
     }
 
     @IsTest
-    private static void queryWithFragmentTest() {
+    private static void queryWithFragmentDefinitionTest() {
         GraphQLFragmentNode fragment = new GraphQLFragmentNode('fragment1', 'Type1');
 
-        GraphQLQueryNode node = new GraphQLQueryNode().withFragment(fragment);
+        GraphQLQueryNode node = new GraphQLQueryNode().defineFragment(fragment);
 
         System.assert(node.hasFragments());
         System.assertEquals(1, node.fragments.size());
@@ -113,13 +113,13 @@ private class GraphQLQueryNodeTest {
     }
 
     @IsTest
-    private static void queryWithFragmentsTest() {
+    private static void queryWithFragmentDefinitionsTest() {
         List<GraphQLFragmentNode> fragments = new List<GraphQLFragmentNode> {
             new GraphQLFragmentNode('fragment1', 'Type1'),
             new GraphQLFragmentNode('fragment2', 'Type2')
         };
 
-        GraphQLQueryNode node = new GraphQLQueryNode().withFragments(fragments);
+        GraphQLQueryNode node = new GraphQLQueryNode().defineFragments(fragments);
 
         System.assert(node.hasFragments());
         System.assertEquals(fragments.size(), node.fragments.size());
@@ -149,10 +149,10 @@ private class GraphQLQueryNodeTest {
     }
 
     @IsTest
-    private static void queryWithVariableTest() {
+    private static void queryWithVariableDefinitionTest() {
         GraphQLQueryNode node = new GraphQLQueryNode()
             .withNode(new GraphQLNode('node'))
-            .withVariable('newVariable', '[Int]! = 0');
+            .defineVariable('newVariable', '[Int]! = 0');
 
         System.assertEquals(1, node.variables.size());
     }
@@ -189,7 +189,7 @@ private class GraphQLQueryNodeTest {
     }
 
     @IsTest
-    private static void buildQueryWithVariablesPositiveTest() {
+    private static void buildQueryWithVariableDefinitionsPositiveTest() {
         List<GraphQLNode> nodes = new List<GraphQLNode> {
             new GraphQLNode('node1').withArgument('arg', '$param1'),
             new GraphQLNode('node2')
@@ -199,8 +199,8 @@ private class GraphQLQueryNodeTest {
         GraphQLQueryNode query = new GraphQLQueryNode()
             .withNodes(nodes)
             .withFields(fields)
-            .withVariable('param1', 'Int!')
-            .withVariable('param2', 'String');
+            .defineVariable('param1', 'Int!')
+            .defineVariable('param2', 'String');
 
         System.assert(query != null);
         System.assert(String.isBlank(query.name));
@@ -246,7 +246,7 @@ private class GraphQLQueryNodeTest {
             new GraphQLNode('node2').withFragment(fragments.get(1).name)
         };
 
-        GraphQLQueryNode query = new GraphQLQueryNode().withNodes(nodes).withFragments(fragments);
+        GraphQLQueryNode query = new GraphQLQueryNode().withNodes(nodes).defineFragments(fragments);
 
         System.assertEquals(
             'query{node1{...Fields1},node2{...Fields2}}' +

--- a/src/test/classes/GraphQLQueryNodeTest.cls
+++ b/src/test/classes/GraphQLQueryNodeTest.cls
@@ -128,6 +128,21 @@ private class GraphQLQueryNodeTest {
     }
 
     @IsTest
+    private static void queryWithInlineFragmentDefinitionNegativeTest() {
+        GraphQLFragmentNode fragment = new GraphQLFragmentNode('Type1');
+
+        Exception error;
+        try {
+            new GraphQLQueryNode().defineFragment(fragment);
+        } catch (Exception ex) {
+            error = ex;
+        }
+
+        System.assert(error != null);
+        System.assert(error instanceof GraphQLOperationNode.GraphQLOperationNodeException);
+    }
+
+    @IsTest
     private static void queryWithNodeTest() {
         String nodeName = 'node1';
 

--- a/src/test/classes/GraphQLSubscriptionNodeTest.cls
+++ b/src/test/classes/GraphQLSubscriptionNodeTest.cls
@@ -102,10 +102,10 @@ private class GraphQLSubscriptionNodeTest {
     }
 
     @IsTest
-    private static void subscriptionWithFragmentTest() {
+    private static void subscriptionWithFragmentDefinitionTest() {
         GraphQLFragmentNode fragment = new GraphQLFragmentNode('fragment1', 'Type1');
 
-        GraphQLSubscriptionNode node = new GraphQLSubscriptionNode().withFragment(fragment);
+        GraphQLSubscriptionNode node = new GraphQLSubscriptionNode().defineFragment(fragment);
 
         System.assert(node.hasFragments());
         System.assertEquals(1, node.fragments.size());
@@ -113,13 +113,13 @@ private class GraphQLSubscriptionNodeTest {
     }
 
     @IsTest
-    private static void subscriptionWithFragmentsTest() {
+    private static void subscriptionWithFragmentDefinitionsTest() {
         List<GraphQLFragmentNode> fragments = new List<GraphQLFragmentNode> {
             new GraphQLFragmentNode('fragment1', 'Type1'),
             new GraphQLFragmentNode('fragment2', 'Type2')
         };
 
-        GraphQLSubscriptionNode node = new GraphQLSubscriptionNode().withFragments(fragments);
+        GraphQLSubscriptionNode node = new GraphQLSubscriptionNode().defineFragments(fragments);
 
         System.assert(node.hasFragments());
         System.assertEquals(fragments.size(), node.fragments.size());
@@ -149,10 +149,10 @@ private class GraphQLSubscriptionNodeTest {
     }
 
     @IsTest
-    private static void subscriptionWithVariableTest() {
+    private static void subscriptionWithVariableDefinitionTest() {
         GraphQLSubscriptionNode node = new GraphQLSubscriptionNode()
             .withNode(new GraphQLNode('node'))
-            .withVariable('newVariable', '[Int]! = 0');
+            .defineVariable('newVariable', '[Int]! = 0');
 
         System.assertEquals(1, node.variables.size());
     }
@@ -193,7 +193,7 @@ private class GraphQLSubscriptionNodeTest {
     }
 
     @IsTest
-    private static void buildSubscriptionWithVariablesPositiveTest() {
+    private static void buildSubscriptionWithVariableDefinitionsPositiveTest() {
         List<GraphQLNode> nodes = new List<GraphQLNode> {
             new GraphQLNode('node1').withArgument('arg', '$param1'),
             new GraphQLNode('node2')
@@ -203,8 +203,8 @@ private class GraphQLSubscriptionNodeTest {
         GraphQLSubscriptionNode subscription = new GraphQLSubscriptionNode()
             .withNodes(nodes)
             .withFields(fields)
-            .withVariable('param1', 'Int!')
-            .withVariable('param2', 'String');
+            .defineVariable('param1', 'Int!')
+            .defineVariable('param2', 'String');
 
         System.assert(subscription != null);
         System.assert(String.isBlank(subscription.name));


### PR DESCRIPTION
### What does this PR do?

Allows developers to use inline fragments where necessary instead of defining and attaching them separately. This also allows fetching different fields depending on the result fragment type.

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.  
[x] The documentation has been updated according to the introduced/changed components.  
[x] ApexDoc comments have been attached to all `global` classes, fields, properties and methods.
