### PR TITLE
Remove DefaultEndpoint config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@ Now, every global class, field, property, method has ApexDoc comments so that it
 
 ## What's changed
 
+### The `DefaultGraphQLEndpoint` custom metadata configuration has been deleted
+
+This custom metadata record was not really necessary and could cause confusion.
+
 ### `IGraphQLParser` and `IGraphQLClient` interfaces have been deleted
 
 These interfaces have been deleted from the package as they were not useful and did not serve any purpose. Hope this makes the code more clean and easy to understand!

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,14 +12,13 @@ All classes available for use can be found [here](types). There is also a short 
 
 Configuration capabilities are provided by using the Custom Metadata Type `GraphQLClientConfig__mdt`. Each record represents a piece of configuration. All existing records are described in the table below:
 
-| Label                               | Name                           | Default Value       | Type    | Description                                                                                      |
-| ----------------------------------- | ------------------------------ | ------------------- | ------- | ------------------------------------------------------------------------------------------------ |
-| Date Argument Format                | DateArgumentFormat             | MM/dd/yyyy          | String  | The format of the date arguments, passed to a query                                              |
-| DateTime Argument Format            | DateTimeArgumentFormat         | yyyy-MM-dd HH:mm:ss | String  | The format of the date-time arguments, passed to a query                                         |
-| Default GraphQL Endpoint            | DefaultGraphQLEndpoint         | null                | String  | The default GraphQL endpoint url that will be used for `GraphQLHttpClient`. By default it's null |
-| Max Query Depth                     | MaxQueryDepth                  | 10                  | Integer | The number of depth levels each node or query can have                                           |
-| Query Indent Size                   | QueryIndentSize                | 2                   | Integer | The number of spaces that will be used as indent for pretty-formatted nodes and queries          |
-| Send Pretty Query                   | SendPrettyQuery                | false               | Boolean | Whether to send well-formatted GraphQL queries to the endpoint or not                            |
-| Suppress Nulls For Object Arguments | SupressNullsForObjectArguments | true                | Boolean | Whether to suppress null values for the object arguments in nodes or not                         |
+| Label                               | Name                           | Default Value       | Type    | Description                                                                             |
+| ----------------------------------- | ------------------------------ | ------------------- | ------- | --------------------------------------------------------------------------------------- |
+| Date Argument Format                | DateArgumentFormat             | MM/dd/yyyy          | String  | The format of the date arguments, passed to a query                                     |
+| DateTime Argument Format            | DateTimeArgumentFormat         | yyyy-MM-dd HH:mm:ss | String  | The format of the date-time arguments, passed to a query                                |
+| Max Query Depth                     | MaxQueryDepth                  | 10                  | Integer | The number of depth levels each node or query can have                                  |
+| Query Indent Size                   | QueryIndentSize                | 2                   | Integer | The number of spaces that will be used as indent for pretty-formatted nodes and queries |
+| Send Pretty Query                   | SendPrettyQuery                | false               | Boolean | Whether to send well-formatted GraphQL queries to the endpoint or not                   |
+| Suppress Nulls For Object Arguments | SupressNullsForObjectArguments | true                | Boolean | Whether to suppress null values for the object arguments in nodes or not                |
 
 You can change each of these settings but do not change their names (`DeveloperName` field), it can lead to issues working with the package.

--- a/src/main/default/classes/client/GraphQLHttpClient.cls
+++ b/src/main/default/classes/client/GraphQLHttpClient.cls
@@ -7,24 +7,14 @@ global class GraphQLHttpClient {
     private static final Boolean SEND_PRETTY_REQUEST = GraphQLConfigManager.getBoolean(GraphQLConfig.SendPrettyQuery);
 
     /**
-     * @description Create an instance of the client taking the GraphQL endpoint from the `GraphQLClientConfig__mdt`
-     * @throws GraphQLHttpClientException If the the `GraphQLClientConfig__mdt` `DefaultGraphQLEndpoint` config is null or empty
-     */
-    global GraphQLHttpClient() {
-        this(GraphQLConfigManager.getString(GraphQLConfig.DefaultGraphQLEndpoint));
-    }
-
-    /**
-     * @description Create an instance of the client passinf the GraphQL endpoint
+     * @description Create an instance of the client passing the GraphQL endpoint
      * @param endpoint The GraphQL endpoint
      * @throws GraphQLHttpClientException If the the provided endpoint is null or empty
      */
     global GraphQLHttpClient(String endpoint) {
         this.endpoint = endpoint;
-        if (String.isBlank(this.endpoint) || this.endpoint == 'null') {
-            throw new GraphQLHttpClientException(
-                'GraphQL endpoint cannot be empty. Provide valid endpoint URL or specify default endpoint in the custom metadata'
-            );
+        if (String.isBlank(endpoint)) {
+            throw new GraphQLHttpClientException('GraphQL endpoint cannot be null');
         }
     }
 
@@ -132,5 +122,6 @@ global class GraphQLHttpClient {
         }
     }
 
+    @TestVisible
     private class GraphQLHttpClientException extends Exception {}
 }

--- a/src/main/default/classes/configs/GraphQLConfig.cls
+++ b/src/main/default/classes/configs/GraphQLConfig.cls
@@ -4,6 +4,5 @@ public enum GraphQLConfig {
     SupressNullsForObjectArguments,
     DateArgumentFormat,
     DateTimeArgumentFormat,
-    DefaultGraphQLEndpoint,
     SendPrettyQuery
 }

--- a/src/main/default/customMetadata/GraphQLClientConfig.DefaultGraphQLEndpoint.md-meta.xml
+++ b/src/main/default/customMetadata/GraphQLClientConfig.DefaultGraphQLEndpoint.md-meta.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Default GraphQL Endpoint</label>
-    <protected>true</protected>
-    <values>
-        <field>Value__c</field>
-        <value xsi:type="xsd:string">null</value>
-    </values>
-</CustomMetadata>

--- a/src/test/classes/GraphQLHttpClientTest.cls
+++ b/src/test/classes/GraphQLHttpClientTest.cls
@@ -4,20 +4,15 @@ private class GraphQLHttpClientTest {
 
     @IsTest
     private static void createClientWithoutEndpointNegativeTest() {
-        GraphQLHttpClient client;
         Exception error;
         try {
-            client = new GraphQLHttpClient();
+            new GraphQLHttpClient('');
         } catch (Exception ex) {
             error = ex;
         }
 
-        System.assert(client == null);
         System.assert(error != null);
-        System.assertEquals(
-            'GraphQL endpoint cannot be empty. Provide valid endpoint URL or specify default endpoint in the custom metadata',
-            error.getMessage()
-        );
+        System.assert(error instanceof GraphQLHttpClient.GraphQLHttpClientException);
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

This PR removes the `DefaultGraphQLEndpoint` custom metadata config. This custom metadata record was not really necessary and could cause confusion.

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.  
[x] The documentation has been updated according to the introduced/changed components.  
[x] ApexDoc comments have been attached to all `global` classes, fields, properties and methods.

