### PR TITLE
Allow enum arrays as arguments

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,32 @@
+# Version 2.1
+
+## Breaking changes
+
+### `asEnum()` method is deleted for `GraphQLArgument` and `GraphQLVariable` classes
+
+That was done because these methods are not needed anymore with introduction of the new `GraphQLEnum` class, which can be used for passing enum values into arguments and variable default values.
+
+Example:
+
+```gql
+{
+    countryByCode(code: CODE_NL) {
+        name
+    }
+}
+```
+
+Apex equivalent:
+
+```java
+GraphQLField countryByCode = new GraphQLField('countryByCode')
+    .withField('name')
+    .withArgument('code', new GraphQLEnum('CODE_NL'));
+
+GraphQLQuery query = new GraphQLQuery(countryByCode);
+System.debug(query.build(true));
+```
+
 # Version 2.0
 
 SFDX package name and version: gql-apex-client@2.0.0
@@ -5,7 +34,7 @@ Package Id: 04t5Y000001zNZLQA2
 
 All information regarding the installation and usage is described on the [main repo page](https://github.com/IlyaMatsuev/Apex-GraphQL-Client).
 
-## Beaking changes
+## Breaking changes
 
 ### Package classes amd methods naming changes
 

--- a/docs/types/Client/GraphQLHttpClient.md
+++ b/docs/types/Client/GraphQLHttpClient.md
@@ -38,9 +38,9 @@ Send GraphQL request (Query or Mutation) and wait for the response
 
 #### Returns
 
-| Type            | Description                                                       |
-| --------------- | ----------------------------------------------------------------- |
-| GraphQLResponse | The `GraphQLResponse` instance containing parsed GraphQL response |
+| Type            | Description                                                                                         |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| GraphQLResponse | The [GraphQLResponse](/types/Client/GraphQLResponse.md) instance containing parsed GraphQL response |
 
 ### `global Id sendAsync(GraphQLRequest request, IGraphQLResponseCallback callback)`
 
@@ -48,10 +48,10 @@ Send GraphQL request (Query or Mutation) without awaiting the response or passin
 
 #### Parameters
 
-| Param      | Description                                                                              |
-| ---------- | ---------------------------------------------------------------------------------------- |
-| `request`  | The instance of request to be send                                                       |
-| `callback` | The instance of `IGraphQLResponseCallback` implementing the callback method. Can be null |
+| Param      | Description                                                                                                                         |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `request`  | The instance of request to be send                                                                                                  |
+| `callback` | The instance of [IGraphQLResponseCallback](/types/Client/IGraphQLResponseCallback.md) implementing the callback method. Can be null |
 
 #### Returns
 

--- a/docs/types/Client/GraphQLRequest.md
+++ b/docs/types/Client/GraphQLRequest.md
@@ -28,16 +28,16 @@ Create an instance using a GraphQL node for a specific GraphQL operation (Query 
 
 #### Parameters
 
-| Param       | Description                                                                    |
-| ----------- | ------------------------------------------------------------------------------ |
-| `operation` | The instance of the `GraphQLOperationType` enum (`Query` or `Mutation`)        |
-| `node`      | The instance of the Graph operation node (`GraphQLQuery` or `GraphQLMutation`) |
+| Param       | Description                                                                                                                                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `operation` | The instance of the [GraphQLOperationType](/types/Operations/GraphQLOperationType.md) enum (`Query` or `Mutation`)                                      |
+| `node`      | The instance of the Graph operation node ([GraphQLQuery](/types/Operations/GraphQLQuery.md) or [GraphQLMutation](/types/Operations/GraphQLMutation.md)) |
 
 #### Throws
 
-| Exception                 | Description                                                              |
-| ------------------------- | ------------------------------------------------------------------------ |
-| `GraphQLRequestException` | If the provided instance is neither `GraphQLQuery` nor `GraphQLMutation` |
+| Exception                 | Description                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `GraphQLRequestException` | If the provided instance is neither [GraphQLQuery](/types/Operations/GraphQLQuery.md) nor <GraphQLMutation>> |
 
 ---
 
@@ -76,9 +76,9 @@ Add a custom header to the request. For example `Authorization`
 
 #### Returns
 
-| Type           | Description                           |
-| -------------- | ------------------------------------- |
-| GraphQLRequest | The current `GraphQLRequest` instance |
+| Type           | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| GraphQLRequest | The current [GraphQLRequest](/types/Client/GraphQLRequest.md) instance |
 
 ### `global GraphQLRequest withHeaders(Map<String,String> headers)`
 
@@ -92,9 +92,9 @@ Add multiple custom headers to the request. For example `Authorization`
 
 #### Returns
 
-| Type           | Description                           |
-| -------------- | ------------------------------------- |
-| GraphQLRequest | The current `GraphQLRequest` instance |
+| Type           | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| GraphQLRequest | The current [GraphQLRequest](/types/Client/GraphQLRequest.md) instance |
 
 ### `global GraphQLRequest withTimeout(Integer timeout)`
 
@@ -108,9 +108,9 @@ Set a timeout for the GraphQL request
 
 #### Returns
 
-| Type           | Description                           |
-| -------------- | ------------------------------------- |
-| GraphQLRequest | The current `GraphQLRequest` instance |
+| Type           | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| GraphQLRequest | The current [GraphQLRequest](/types/Client/GraphQLRequest.md) instance |
 
 ### `global GraphQLRequest withVariable(String name, Object value)`
 
@@ -125,9 +125,9 @@ Add a variable definition value to the request
 
 #### Returns
 
-| Type           | Description                           |
-| -------------- | ------------------------------------- |
-| GraphQLRequest | The current `GraphQLRequest` instance |
+| Type           | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| GraphQLRequest | The current [GraphQLRequest](/types/Client/GraphQLRequest.md) instance |
 
 ### `global GraphQLRequest withVariables(Map<String,Object> variables)`
 
@@ -141,9 +141,9 @@ Add multiple variable definition values to the request
 
 #### Returns
 
-| Type           | Description                           |
-| -------------- | ------------------------------------- |
-| GraphQLRequest | The current `GraphQLRequest` instance |
+| Type           | Description                                                            |
+| -------------- | ---------------------------------------------------------------------- |
+| GraphQLRequest | The current [GraphQLRequest](/types/Client/GraphQLRequest.md) instance |
 
 ### `global override String toString()`
 

--- a/docs/types/Client/GraphQLResponse.md
+++ b/docs/types/Client/GraphQLResponse.md
@@ -32,9 +32,9 @@ Get the list of errors in the response
 
 #### Returns
 
-| Type                       | Description                                                                                           |
-| -------------------------- | ----------------------------------------------------------------------------------------------------- |
-| List<GraphQLResponseError> | The list of `GraphQLResponseError` instances if there are any errors. Returns an empty list otherwise |
+| Type                       | Description                                                                                                                                  |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| List<GraphQLResponseError> | The list of [GraphQLResponseError](/types/Client/GraphQLResponseError.md) instances if there are any errors. Returns an empty list otherwise |
 
 ### `global Map getData()`
 

--- a/docs/types/Client/GraphQLVariable.md
+++ b/docs/types/Client/GraphQLVariable.md
@@ -81,21 +81,4 @@ Adds a default value to the variable definition
 | --------------- | ----------------------------------------------- |
 | GraphQLVariable | The current instance of the variable definition |
 
-### `global GraphQLVariable asEnum()`
-
-Represents the current variable default value as a GraphQL enum value
-
-#### Returns
-
-| Type            | Description                                     |
-| --------------- | ----------------------------------------------- |
-| GraphQLVariable | The current instance of the variable definition |
-
-#### Throws
-
-| Exception                  | Description                                                        |
-| -------------------------- | ------------------------------------------------------------------ |
-| `GraphQLVariableException` | If the doesn't have any default value set yet                      |
-| `GraphQLArgumentException` | If the default value is not String or if it's a variable reference |
-
 ---

--- a/docs/types/Operations/GraphQLMutation.md
+++ b/docs/types/Operations/GraphQLMutation.md
@@ -141,9 +141,9 @@ Add a child field to the current mutation node
 
 #### Returns
 
-| Type            | Description                                         |
-| --------------- | --------------------------------------------------- |
-| GraphQLMutation | The instance of the current `GraphQLMutation` class |
+| Type            | Description                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| GraphQLMutation | The instance of the current [GraphQLMutation](/types/Operations/GraphQLMutation.md) class |
 
 ### `global GraphQLMutation withFields(String fields)`
 
@@ -157,9 +157,9 @@ Add multiple child fields to the current mutation node
 
 #### Returns
 
-| Type            | Description                                         |
-| --------------- | --------------------------------------------------- |
-| GraphQLMutation | The instance of the current `GraphQLMutation` class |
+| Type            | Description                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| GraphQLMutation | The instance of the current [GraphQLMutation](/types/Operations/GraphQLMutation.md) class |
 
 ### `global GraphQLMutation withField(GraphQLField fieldNode)`
 
@@ -173,9 +173,9 @@ Add a child node to the current mutation node
 
 #### Returns
 
-| Type            | Description                                         |
-| --------------- | --------------------------------------------------- |
-| GraphQLMutation | The instance of the current `GraphQLMutation` class |
+| Type            | Description                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| GraphQLMutation | The instance of the current [GraphQLMutation](/types/Operations/GraphQLMutation.md) class |
 
 ### `global GraphQLMutation withFields(GraphQLField fieldNodes)`
 
@@ -189,9 +189,9 @@ Add multiple child nodes to the current mutation node
 
 #### Returns
 
-| Type            | Description                                         |
-| --------------- | --------------------------------------------------- |
-| GraphQLMutation | The instance of the current `GraphQLMutation` class |
+| Type            | Description                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| GraphQLMutation | The instance of the current [GraphQLMutation](/types/Operations/GraphQLMutation.md) class |
 
 ### `global GraphQLMutation withDirective(GraphQLDirective directive)`
 
@@ -205,9 +205,9 @@ Add a custom directive to the current mutation node
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLMutation | The current instance of `GraphQLMutation` |
+| Type            | Description                                                                     |
+| --------------- | ------------------------------------------------------------------------------- |
+| GraphQLMutation | The current instance of [GraphQLMutation](/types/Operations/GraphQLMutation.md) |
 
 ### `global GraphQLMutation defineFragment(GraphQLFragment fragment)`
 
@@ -221,9 +221,9 @@ Add a fragment definition for the current mutation node
 
 #### Returns
 
-| Type            | Description                                         |
-| --------------- | --------------------------------------------------- |
-| GraphQLMutation | The instance of the current `GraphQLMutation` class |
+| Type            | Description                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| GraphQLMutation | The instance of the current [GraphQLMutation](/types/Operations/GraphQLMutation.md) class |
 
 #### Throws
 
@@ -243,9 +243,9 @@ Add multiple fragment definitions for the current mutation node
 
 #### Returns
 
-| Type            | Description                                         |
-| --------------- | --------------------------------------------------- |
-| GraphQLMutation | The instance of the current `GraphQLMutation` class |
+| Type            | Description                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| GraphQLMutation | The instance of the current [GraphQLMutation](/types/Operations/GraphQLMutation.md) class |
 
 #### Throws
 
@@ -266,9 +266,9 @@ Add a variable definition for the current mutation node
 
 #### Returns
 
-| Type            | Description                                         |
-| --------------- | --------------------------------------------------- |
-| GraphQLMutation | The instance of the current `GraphQLMutation` class |
+| Type            | Description                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| GraphQLMutation | The instance of the current [GraphQLMutation](/types/Operations/GraphQLMutation.md) class |
 
 ### `global GraphQLMutation defineVariable(GraphQLVariable variable)`
 
@@ -282,9 +282,9 @@ Add a variable definition for the current mutation node
 
 #### Returns
 
-| Type            | Description                                         |
-| --------------- | --------------------------------------------------- |
-| GraphQLMutation | The instance of the current `GraphQLMutation` class |
+| Type            | Description                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| GraphQLMutation | The instance of the current [GraphQLMutation](/types/Operations/GraphQLMutation.md) class |
 
 ### `global override GraphQLOperationType getOperation()`
 
@@ -328,33 +328,33 @@ Create a GraphQL request from the current operation node
 
 #### Returns
 
-| Type           | Description                                |
-| -------------- | ------------------------------------------ |
-| GraphQLRequest | The instance of the `GraphQLRequest` class |
+| Type           | Description                                                                 |
+| -------------- | --------------------------------------------------------------------------- |
+| GraphQLRequest | The instance of the [GraphQLRequest](/types/Client/GraphQLRequest.md) class |
 
 ### `global Boolean isFieldNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLField`
+Check if the current node is an instance of [GraphQLField](/types/Query/GraphQLField.md)
 
 #### Returns
 
-| Type    | Description                                      |
-| ------- | ------------------------------------------------ |
-| Boolean | `true` if the current instance is `GraphQLField` |
+| Type    | Description                                                                    |
+| ------- | ------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global Boolean isFragmentNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLFragment`
+Check if the current node is an instance of [GraphQLFragment](/types/Query/GraphQLFragment.md)
 
 #### Returns
 
-| Type    | Description                                         |
-| ------- | --------------------------------------------------- |
-| Boolean | `true` if the current instance is `GraphQLFragment` |
+| Type    | Description                                                                          |
+| ------- | ------------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global Boolean hasField(GraphQLField field)`
 

--- a/docs/types/Operations/GraphQLOperation.md
+++ b/docs/types/Operations/GraphQLOperation.md
@@ -68,9 +68,9 @@ Create a GraphQL request from the current operation node
 
 #### Returns
 
-| Type           | Description                                |
-| -------------- | ------------------------------------------ |
-| GraphQLRequest | The instance of the `GraphQLRequest` class |
+| Type           | Description                                                                 |
+| -------------- | --------------------------------------------------------------------------- |
+| GraphQLRequest | The instance of the [GraphQLRequest](/types/Client/GraphQLRequest.md) class |
 
 ### `global GraphQLOperationType getOperation()`
 
@@ -78,33 +78,33 @@ Get the GraphQL operation type of the current node
 
 #### Returns
 
-| Type                 | Description                                     |
-| -------------------- | ----------------------------------------------- |
-| GraphQLOperationType | The instance of the `GraphQLOperationType` enum |
+| Type                 | Description                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| GraphQLOperationType | The instance of the [GraphQLOperationType](/types/Operations/GraphQLOperationType.md) enum |
 
 ### `global Boolean isFieldNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLField`
+Check if the current node is an instance of [GraphQLField](/types/Query/GraphQLField.md)
 
 #### Returns
 
-| Type    | Description                                      |
-| ------- | ------------------------------------------------ |
-| Boolean | `true` if the current instance is `GraphQLField` |
+| Type    | Description                                                                    |
+| ------- | ------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global Boolean isFragmentNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLFragment`
+Check if the current node is an instance of [GraphQLFragment](/types/Query/GraphQLFragment.md)
 
 #### Returns
 
-| Type    | Description                                         |
-| ------- | --------------------------------------------------- |
-| Boolean | `true` if the current instance is `GraphQLFragment` |
+| Type    | Description                                                                          |
+| ------- | ------------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global Boolean hasField(GraphQLField field)`
 

--- a/docs/types/Operations/GraphQLQuery.md
+++ b/docs/types/Operations/GraphQLQuery.md
@@ -141,9 +141,9 @@ Add a child field to the current query node
 
 #### Returns
 
-| Type         | Description                                      |
-| ------------ | ------------------------------------------------ |
-| GraphQLQuery | The instance of the current `GraphQLQuery` class |
+| Type         | Description                                                                         |
+| ------------ | ----------------------------------------------------------------------------------- |
+| GraphQLQuery | The instance of the current [GraphQLQuery](/types/Operations/GraphQLQuery.md) class |
 
 ### `global GraphQLQuery withFields(String fields)`
 
@@ -157,9 +157,9 @@ Add multiple child fields to the current query node
 
 #### Returns
 
-| Type         | Description                                      |
-| ------------ | ------------------------------------------------ |
-| GraphQLQuery | The instance of the current `GraphQLQuery` class |
+| Type         | Description                                                                         |
+| ------------ | ----------------------------------------------------------------------------------- |
+| GraphQLQuery | The instance of the current [GraphQLQuery](/types/Operations/GraphQLQuery.md) class |
 
 ### `global GraphQLQuery withField(GraphQLField fieldNode)`
 
@@ -173,9 +173,9 @@ Add a child node to the current query node
 
 #### Returns
 
-| Type         | Description                                      |
-| ------------ | ------------------------------------------------ |
-| GraphQLQuery | The instance of the current `GraphQLQuery` class |
+| Type         | Description                                                                         |
+| ------------ | ----------------------------------------------------------------------------------- |
+| GraphQLQuery | The instance of the current [GraphQLQuery](/types/Operations/GraphQLQuery.md) class |
 
 ### `global GraphQLQuery withFields(GraphQLField fieldNodes)`
 
@@ -189,9 +189,9 @@ Add multiple child nodes to the current query node
 
 #### Returns
 
-| Type         | Description                                      |
-| ------------ | ------------------------------------------------ |
-| GraphQLQuery | The instance of the current `GraphQLQuery` class |
+| Type         | Description                                                                         |
+| ------------ | ----------------------------------------------------------------------------------- |
+| GraphQLQuery | The instance of the current [GraphQLQuery](/types/Operations/GraphQLQuery.md) class |
 
 ### `global GraphQLQuery withDirective(GraphQLDirective directive)`
 
@@ -205,9 +205,9 @@ Add a custom directive to the current query node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLQuery | The current instance of `GraphQLQuery` |
+| Type         | Description                                                               |
+| ------------ | ------------------------------------------------------------------------- |
+| GraphQLQuery | The current instance of [GraphQLQuery](/types/Operations/GraphQLQuery.md) |
 
 ### `global GraphQLQuery defineFragment(GraphQLFragment fragment)`
 
@@ -221,9 +221,9 @@ Add a fragment definition for the current query node
 
 #### Returns
 
-| Type         | Description                                      |
-| ------------ | ------------------------------------------------ |
-| GraphQLQuery | The instance of the current `GraphQLQuery` class |
+| Type         | Description                                                                         |
+| ------------ | ----------------------------------------------------------------------------------- |
+| GraphQLQuery | The instance of the current [GraphQLQuery](/types/Operations/GraphQLQuery.md) class |
 
 #### Throws
 
@@ -243,9 +243,9 @@ Add multiple fragment definitions for the current query node
 
 #### Returns
 
-| Type         | Description                                      |
-| ------------ | ------------------------------------------------ |
-| GraphQLQuery | The instance of the current `GraphQLQuery` class |
+| Type         | Description                                                                         |
+| ------------ | ----------------------------------------------------------------------------------- |
+| GraphQLQuery | The instance of the current [GraphQLQuery](/types/Operations/GraphQLQuery.md) class |
 
 #### Throws
 
@@ -266,9 +266,9 @@ Add a variable definition for the current query node
 
 #### Returns
 
-| Type         | Description                                      |
-| ------------ | ------------------------------------------------ |
-| GraphQLQuery | The instance of the current `GraphQLQuery` class |
+| Type         | Description                                                                         |
+| ------------ | ----------------------------------------------------------------------------------- |
+| GraphQLQuery | The instance of the current [GraphQLQuery](/types/Operations/GraphQLQuery.md) class |
 
 ### `global GraphQLQuery defineVariable(GraphQLVariable variable)`
 
@@ -282,9 +282,9 @@ Add a variable definition for the current query node
 
 #### Returns
 
-| Type         | Description                                      |
-| ------------ | ------------------------------------------------ |
-| GraphQLQuery | The instance of the current `GraphQLQuery` class |
+| Type         | Description                                                                         |
+| ------------ | ----------------------------------------------------------------------------------- |
+| GraphQLQuery | The instance of the current [GraphQLQuery](/types/Operations/GraphQLQuery.md) class |
 
 ### `global override GraphQLOperationType getOperation()`
 
@@ -328,33 +328,33 @@ Create a GraphQL request from the current operation node
 
 #### Returns
 
-| Type           | Description                                |
-| -------------- | ------------------------------------------ |
-| GraphQLRequest | The instance of the `GraphQLRequest` class |
+| Type           | Description                                                                 |
+| -------------- | --------------------------------------------------------------------------- |
+| GraphQLRequest | The instance of the [GraphQLRequest](/types/Client/GraphQLRequest.md) class |
 
 ### `global Boolean isFieldNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLField`
+Check if the current node is an instance of [GraphQLField](/types/Query/GraphQLField.md)
 
 #### Returns
 
-| Type    | Description                                      |
-| ------- | ------------------------------------------------ |
-| Boolean | `true` if the current instance is `GraphQLField` |
+| Type    | Description                                                                    |
+| ------- | ------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global Boolean isFragmentNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLFragment`
+Check if the current node is an instance of [GraphQLFragment](/types/Query/GraphQLFragment.md)
 
 #### Returns
 
-| Type    | Description                                         |
-| ------- | --------------------------------------------------- |
-| Boolean | `true` if the current instance is `GraphQLFragment` |
+| Type    | Description                                                                          |
+| ------- | ------------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global Boolean hasField(GraphQLField field)`
 

--- a/docs/types/Operations/GraphQLSubscription.md
+++ b/docs/types/Operations/GraphQLSubscription.md
@@ -141,9 +141,9 @@ Add a child field to the current subscription node
 
 #### Returns
 
-| Type                | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| GraphQLSubscription | The instance of the current `GraphQLSubscription` class |
+| Type                | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| GraphQLSubscription | The instance of the current [GraphQLSubscription](/types/Operations/GraphQLSubscription.md) class |
 
 ### `global GraphQLSubscription withFields(String fields)`
 
@@ -157,9 +157,9 @@ Add multiple child fields to the current subscription node
 
 #### Returns
 
-| Type                | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| GraphQLSubscription | The instance of the current `GraphQLSubscription` class |
+| Type                | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| GraphQLSubscription | The instance of the current [GraphQLSubscription](/types/Operations/GraphQLSubscription.md) class |
 
 ### `global GraphQLSubscription withField(GraphQLField fieldNode)`
 
@@ -173,9 +173,9 @@ Add a child node to the current subscription node
 
 #### Returns
 
-| Type                | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| GraphQLSubscription | The instance of the current `GraphQLSubscription` class |
+| Type                | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| GraphQLSubscription | The instance of the current [GraphQLSubscription](/types/Operations/GraphQLSubscription.md) class |
 
 ### `global GraphQLSubscription withFields(GraphQLField fieldNodes)`
 
@@ -189,9 +189,9 @@ Add multiple child nodes to the current subscription node
 
 #### Returns
 
-| Type                | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| GraphQLSubscription | The instance of the current `GraphQLSubscription` class |
+| Type                | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| GraphQLSubscription | The instance of the current [GraphQLSubscription](/types/Operations/GraphQLSubscription.md) class |
 
 ### `global GraphQLSubscription withDirective(GraphQLDirective directive)`
 
@@ -205,9 +205,9 @@ Add a custom directive to the current subscription node
 
 #### Returns
 
-| Type                | Description                                   |
-| ------------------- | --------------------------------------------- |
-| GraphQLSubscription | The current instance of `GraphQLSubscription` |
+| Type                | Description                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------- |
+| GraphQLSubscription | The current instance of [GraphQLSubscription](/types/Operations/GraphQLSubscription.md) |
 
 ### `global GraphQLSubscription defineFragment(GraphQLFragment fragment)`
 
@@ -221,9 +221,9 @@ Add a fragment definition for the current subscription node
 
 #### Returns
 
-| Type                | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| GraphQLSubscription | The instance of the current `GraphQLSubscription` class |
+| Type                | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| GraphQLSubscription | The instance of the current [GraphQLSubscription](/types/Operations/GraphQLSubscription.md) class |
 
 #### Throws
 
@@ -243,9 +243,9 @@ Add multiple fragment definitions for the current subscription node
 
 #### Returns
 
-| Type                | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| GraphQLSubscription | The instance of the current `GraphQLSubscription` class |
+| Type                | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| GraphQLSubscription | The instance of the current [GraphQLSubscription](/types/Operations/GraphQLSubscription.md) class |
 
 #### Throws
 
@@ -266,9 +266,9 @@ Add a variable definition for the current subscription node
 
 #### Returns
 
-| Type                | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| GraphQLSubscription | The instance of the current `GraphQLSubscription` class |
+| Type                | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| GraphQLSubscription | The instance of the current [GraphQLSubscription](/types/Operations/GraphQLSubscription.md) class |
 
 ### `global GraphQLSubscription defineVariable(GraphQLVariable variable)`
 
@@ -282,9 +282,9 @@ Add a variable definition for the current subscription node
 
 #### Returns
 
-| Type                | Description                                             |
-| ------------------- | ------------------------------------------------------- |
-| GraphQLSubscription | The instance of the current `GraphQLSubscription` class |
+| Type                | Description                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------- |
+| GraphQLSubscription | The instance of the current [GraphQLSubscription](/types/Operations/GraphQLSubscription.md) class |
 
 ### `global override GraphQLRequest asRequest()`
 
@@ -340,25 +340,25 @@ Check the current operation node has any defined fragments
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLField`
+Check if the current node is an instance of [GraphQLField](/types/Query/GraphQLField.md)
 
 #### Returns
 
-| Type    | Description                                      |
-| ------- | ------------------------------------------------ |
-| Boolean | `true` if the current instance is `GraphQLField` |
+| Type    | Description                                                                    |
+| ------- | ------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global Boolean isFragmentNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLFragment`
+Check if the current node is an instance of [GraphQLFragment](/types/Query/GraphQLFragment.md)
 
 #### Returns
 
-| Type    | Description                                         |
-| ------- | --------------------------------------------------- |
-| Boolean | `true` if the current instance is `GraphQLFragment` |
+| Type    | Description                                                                          |
+| ------- | ------------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global Boolean hasField(GraphQLField field)`
 

--- a/docs/types/Query/GraphQLArgument.md
+++ b/docs/types/Query/GraphQLArgument.md
@@ -23,17 +23,13 @@ Create an instance of an argument by the provided name and value
 
 The argument name
 
-### `global value` → `Object`
-
-The argument value
-
----
-
-## Properties
-
 ### `global type` → `GraphQLArgumentType`
 
 The argument GraphQL type
+
+### `global value` → `Object`
+
+The argument value
 
 ---
 
@@ -48,21 +44,5 @@ Check if the current argument references a variable
 | Type    | Description                                                             |
 | ------- | ----------------------------------------------------------------------- |
 | Boolean | `true` if the current argument references a variable. `false` otherwise |
-
-### `global GraphQLArgument asEnum()`
-
-Represents the current argument as a GraphQL enum value
-
-#### Returns
-
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLArgument | The current instance of `GraphQLArgument` |
-
-#### Throws
-
-| Exception                  | Description                                                                 |
-| -------------------------- | --------------------------------------------------------------------------- |
-| `GraphQLArgumentException` | If the current argument value is not String or if it's a variable reference |
 
 ---

--- a/docs/types/Query/GraphQLDirective.md
+++ b/docs/types/Query/GraphQLDirective.md
@@ -53,9 +53,9 @@ Add an argument to the current directive
 
 #### Returns
 
-| Type             | Description                                |
-| ---------------- | ------------------------------------------ |
-| GraphQLDirective | The current instance of `GraphQLDirective` |
+| Type             | Description                                                                  |
+| ---------------- | ---------------------------------------------------------------------------- |
+| GraphQLDirective | The current instance of [GraphQLDirective](/types/Query/GraphQLDirective.md) |
 
 ### `global GraphQLDirective withArgument(GraphQLArgument argument)`
 
@@ -69,8 +69,8 @@ Add an argument to the current directive
 
 #### Returns
 
-| Type             | Description                                |
-| ---------------- | ------------------------------------------ |
-| GraphQLDirective | The current instance of `GraphQLDirective` |
+| Type             | Description                                                                  |
+| ---------------- | ---------------------------------------------------------------------------- |
+| GraphQLDirective | The current instance of [GraphQLDirective](/types/Query/GraphQLDirective.md) |
 
 ---

--- a/docs/types/Query/GraphQLEnum.md
+++ b/docs/types/Query/GraphQLEnum.md
@@ -1,0 +1,25 @@
+# GraphQLEnum
+
+Represents an enum value used in arguments and variables
+
+## Constructors
+
+### `global GraphQLEnum(String value)`
+
+Creates an instance of GraphQL enum by the provided enum value
+
+#### Parameters
+
+| Param   | Description    |
+| ------- | -------------- |
+| `value` | The enum value |
+
+---
+
+## Fields
+
+### `global value` → `String`
+
+The enum value
+
+---

--- a/docs/types/Query/GraphQLField.md
+++ b/docs/types/Query/GraphQLField.md
@@ -12,11 +12,11 @@ GraphQLField
 
 ### `global GraphQLField()`
 
-Create an instance of `GraphQLField` with the empty name
+Create an instance of [GraphQLField](/types/Query/GraphQLField.md) with the empty name
 
 ### `global GraphQLField(String name)`
 
-Create an instance of `GraphQLField` with the provided name
+Create an instance of [GraphQLField](/types/Query/GraphQLField.md) with the provided name
 
 #### Parameters
 
@@ -26,7 +26,7 @@ Create an instance of `GraphQLField` with the provided name
 
 ### `global GraphQLField(List<GraphQLField> fieldNodes)`
 
-Create an instance of `GraphQLField` with an empty name and child nodes
+Create an instance of [GraphQLField](/types/Query/GraphQLField.md) with an empty name and child nodes
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Create an instance of `GraphQLField` with an empty name and child nodes
 
 ### `global GraphQLField(List<String> fields)`
 
-Create an instance of `GraphQLField` with an empty name and child fields
+Create an instance of [GraphQLField](/types/Query/GraphQLField.md) with an empty name and child fields
 
 #### Parameters
 
@@ -46,7 +46,7 @@ Create an instance of `GraphQLField` with an empty name and child fields
 
 ### `global GraphQLField(String name, List<GraphQLField> fieldNodes)`
 
-Create an instance of `GraphQLField` with the provided name and child nodes
+Create an instance of [GraphQLField](/types/Query/GraphQLField.md) with the provided name and child nodes
 
 #### Parameters
 
@@ -56,7 +56,7 @@ Create an instance of `GraphQLField` with the provided name and child nodes
 
 ### `global GraphQLField(String name, List<String> fields)`
 
-Create an instance of `GraphQLField` with the provided name and child fields
+Create an instance of [GraphQLField](/types/Query/GraphQLField.md) with the provided name and child fields
 
 #### Parameters
 
@@ -124,9 +124,9 @@ Add an alias to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField withField(String field)`
 
@@ -140,9 +140,9 @@ Add a child field to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField withFields(String fields)`
 
@@ -156,9 +156,9 @@ Add multiple child fields to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField withField(GraphQLField fieldNode)`
 
@@ -172,9 +172,9 @@ Add a child node to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField withFields(GraphQLField fieldNodes)`
 
@@ -188,9 +188,9 @@ Add multiple child nodes to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField withFragment(String fragmentName)`
 
@@ -204,9 +204,9 @@ Add a fragment use to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField withFragments(String fragmentNames)`
 
@@ -220,9 +220,9 @@ Add multiple fragment uses to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField withInlineFragment(GraphQLFragment fragment)`
 
@@ -230,15 +230,15 @@ Add an inline fragment to the current node
 
 #### Parameters
 
-| Param      | Description                                                                     |
-| ---------- | ------------------------------------------------------------------------------- |
-| `fragment` | The instance of the `GraphQLFragment`. Should be inline fragment without a name |
+| Param      | Description                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| `fragment` | The instance of the [GraphQLFragment](/types/Query/GraphQLFragment.md). Should be inline fragment without a name |
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 #### Throws
 
@@ -252,15 +252,15 @@ Add inline fragments to the current node
 
 #### Parameters
 
-| Param      | Description                                                                      |
-| ---------- | -------------------------------------------------------------------------------- |
-| `fragment` | The instances of the `GraphQLFragment`. Should be inline fragments without names |
+| Param      | Description                                                                                                       |
+| ---------- | ----------------------------------------------------------------------------------------------------------------- |
+| `fragment` | The instances of the [GraphQLFragment](/types/Query/GraphQLFragment.md). Should be inline fragments without names |
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 #### Throws
 
@@ -281,9 +281,9 @@ Add an argument to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField withArgument(GraphQLArgument argument)`
 
@@ -297,9 +297,9 @@ Add an argument to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField withArguments(GraphQLArgument arguments)`
 
@@ -313,9 +313,9 @@ Add multiple arguments to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField withDirective(GraphQLDirective directive)`
 
@@ -329,9 +329,9 @@ Add a custom directive to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField includeIf(Boolean condition)`
 
@@ -345,9 +345,9 @@ Add the standard `includeIf` directive to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField includeIf(String variable)`
 
@@ -361,9 +361,9 @@ Add the standard `includeIf` directive to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField skipIf(Boolean condition)`
 
@@ -377,9 +377,9 @@ Add the standard `skipIf` directive to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLField skipIf(String variable)`
 
@@ -393,9 +393,9 @@ Add the standard `skipIf` directive to the current node
 
 #### Returns
 
-| Type         | Description                            |
-| ------------ | -------------------------------------- |
-| GraphQLField | The current instance of `GraphQLField` |
+| Type         | Description                                                          |
+| ------------ | -------------------------------------------------------------------- |
+| GraphQLField | The current instance of [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global GraphQLQuery asQuery()`
 
@@ -403,9 +403,9 @@ Convert the current node to the Query node. The arguments and directives are not
 
 #### Returns
 
-| Type         | Description                     |
-| ------------ | ------------------------------- |
-| GraphQLQuery | The new `GraphQLQuery` instance |
+| Type         | Description                                                        |
+| ------------ | ------------------------------------------------------------------ |
+| GraphQLQuery | The new [GraphQLQuery](/types/Operations/GraphQLQuery.md) instance |
 
 ### `global GraphQLMutation asMutation()`
 
@@ -413,9 +413,9 @@ Convert the current node to the Mutation node. The arguments and directives are 
 
 #### Returns
 
-| Type            | Description                        |
-| --------------- | ---------------------------------- |
-| GraphQLMutation | The new `GraphQLMutation` instance |
+| Type            | Description                                                              |
+| --------------- | ------------------------------------------------------------------------ |
+| GraphQLMutation | The new [GraphQLMutation](/types/Operations/GraphQLMutation.md) instance |
 
 ### `global GraphQLSubscription asSubscription()`
 
@@ -423,33 +423,33 @@ Convert the current node to the Subscription node. The arguments and directives 
 
 #### Returns
 
-| Type                | Description                            |
-| ------------------- | -------------------------------------- |
-| GraphQLSubscription | The new `GraphQLSubscription` instance |
+| Type                | Description                                                                      |
+| ------------------- | -------------------------------------------------------------------------------- |
+| GraphQLSubscription | The new [GraphQLSubscription](/types/Operations/GraphQLSubscription.md) instance |
 
 ### `global Boolean isFieldNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLField`
+Check if the current node is an instance of [GraphQLField](/types/Query/GraphQLField.md)
 
 #### Returns
 
-| Type    | Description                                      |
-| ------- | ------------------------------------------------ |
-| Boolean | `true` if the current instance is `GraphQLField` |
+| Type    | Description                                                                    |
+| ------- | ------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global Boolean isFragmentNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLFragment`
+Check if the current node is an instance of [GraphQLFragment](/types/Query/GraphQLFragment.md)
 
 #### Returns
 
-| Type    | Description                                         |
-| ------- | --------------------------------------------------- |
-| Boolean | `true` if the current instance is `GraphQLFragment` |
+| Type    | Description                                                                          |
+| ------- | ------------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global Boolean hasField(GraphQLField field)`
 

--- a/docs/types/Query/GraphQLFragment.md
+++ b/docs/types/Query/GraphQLFragment.md
@@ -124,9 +124,9 @@ Add a field to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global GraphQLFragment withFields(String fields)`
 
@@ -140,9 +140,9 @@ Add multiple fields to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global GraphQLFragment withField(GraphQLField fieldNode)`
 
@@ -156,9 +156,9 @@ Add a node to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global GraphQLFragment withFields(GraphQLField fieldNodes)`
 
@@ -172,9 +172,9 @@ Add multiple nodes to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global GraphQLFragment withFragment(String fragmentName)`
 
@@ -188,9 +188,9 @@ Add another fragment reference to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global GraphQLFragment withFragments(String fragmentNames)`
 
@@ -204,9 +204,9 @@ Add other fragment references to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global GraphQLFragment withInlineFragment(GraphQLFragment fragment)`
 
@@ -214,15 +214,15 @@ Add an inline fragment to the current fragment
 
 #### Parameters
 
-| Param      | Description                                                                     |
-| ---------- | ------------------------------------------------------------------------------- |
-| `fragment` | The instance of the `GraphQLFragment`. Should be inline fragment without a name |
+| Param      | Description                                                                                                      |
+| ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| `fragment` | The instance of the [GraphQLFragment](/types/Query/GraphQLFragment.md). Should be inline fragment without a name |
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 #### Throws
 
@@ -236,15 +236,15 @@ Add inline fragments to the current fragment
 
 #### Parameters
 
-| Param      | Description                                                                      |
-| ---------- | -------------------------------------------------------------------------------- |
-| `fragment` | The instances of the `GraphQLFragment`. Should be inline fragments without names |
+| Param      | Description                                                                                                       |
+| ---------- | ----------------------------------------------------------------------------------------------------------------- |
+| `fragment` | The instances of the [GraphQLFragment](/types/Query/GraphQLFragment.md). Should be inline fragments without names |
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 #### Throws
 
@@ -264,9 +264,9 @@ Add a custom directive to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global GraphQLFragment includeIf(Boolean condition)`
 
@@ -280,9 +280,9 @@ Add the standard `includeIf` directive to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global GraphQLFragment includeIf(String variable)`
 
@@ -296,9 +296,9 @@ Add the standard `includeIf` directive to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global GraphQLFragment skipIf(Boolean condition)`
 
@@ -312,9 +312,9 @@ Add the standard `skipIf` directive to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global GraphQLFragment skipIf(String variable)`
 
@@ -328,33 +328,33 @@ Add the standard `skipIf` directive to the current fragment
 
 #### Returns
 
-| Type            | Description                               |
-| --------------- | ----------------------------------------- |
-| GraphQLFragment | The current instance of `GraphQLFragment` |
+| Type            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| GraphQLFragment | The current instance of [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global Boolean isFieldNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLField`
+Check if the current node is an instance of [GraphQLField](/types/Query/GraphQLField.md)
 
 #### Returns
 
-| Type    | Description                                      |
-| ------- | ------------------------------------------------ |
-| Boolean | `true` if the current instance is `GraphQLField` |
+| Type    | Description                                                                    |
+| ------- | ------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global Boolean isFragmentNode()`
 
 _Inherited_
 
-Check if the current node is an instance of `GraphQLFragment`
+Check if the current node is an instance of [GraphQLFragment](/types/Query/GraphQLFragment.md)
 
 #### Returns
 
-| Type    | Description                                         |
-| ------- | --------------------------------------------------- |
-| Boolean | `true` if the current instance is `GraphQLFragment` |
+| Type    | Description                                                                          |
+| ------- | ------------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global Boolean hasField(GraphQLField field)`
 

--- a/docs/types/Query/GraphQLNode.md
+++ b/docs/types/Query/GraphQLNode.md
@@ -22,23 +22,23 @@ The list of child nodes
 
 ### `global Boolean isFieldNode()`
 
-Check if the current node is an instance of `GraphQLField`
+Check if the current node is an instance of [GraphQLField](/types/Query/GraphQLField.md)
 
 #### Returns
 
-| Type    | Description                                      |
-| ------- | ------------------------------------------------ |
-| Boolean | `true` if the current instance is `GraphQLField` |
+| Type    | Description                                                                    |
+| ------- | ------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLField](/types/Query/GraphQLField.md) |
 
 ### `global Boolean isFragmentNode()`
 
-Check if the current node is an instance of `GraphQLFragment`
+Check if the current node is an instance of [GraphQLFragment](/types/Query/GraphQLFragment.md)
 
 #### Returns
 
-| Type    | Description                                         |
-| ------- | --------------------------------------------------- |
-| Boolean | `true` if the current instance is `GraphQLFragment` |
+| Type    | Description                                                                          |
+| ------- | ------------------------------------------------------------------------------------ |
+| Boolean | `true` if the current instance is [GraphQLFragment](/types/Query/GraphQLFragment.md) |
 
 ### `global Boolean hasField(GraphQLField field)`
 

--- a/docs/types/README.md
+++ b/docs/types/README.md
@@ -14,6 +14,10 @@ The list of all available types for GraphQL arguments
 
 Represents a GraphQL directive
 
+### [GraphQLEnum](/types/Query/GraphQLEnum.md)
+
+Represents an enum value used in arguments and variables
+
 ### [GraphQLField](/types/Query/GraphQLField.md)
 
 The GraphQL node that can be a part of a GraphQL operation

--- a/src/main/default/classes/GraphQLConstants.cls
+++ b/src/main/default/classes/GraphQLConstants.cls
@@ -17,6 +17,8 @@ public class GraphQLConstants {
     public static final String BRACE_RIGHT = '}';
     public static final String PARENTHESE_LEFT = '(';
     public static final String PARENTHESE_RIGHT = ')';
+    public static final String SQUARE_BRACE_LEFT = '[';
+    public static final String SQUARE_BRACE_RIGHT = ']';
 
     public static final Integer FIRST_ELEMENT = 0;
 

--- a/src/main/default/classes/nodes/arguments/GraphQLArgument.cls
+++ b/src/main/default/classes/nodes/arguments/GraphQLArgument.cls
@@ -29,15 +29,7 @@ global class GraphQLArgument {
     /**
      * @description The argument GraphQL type
      */
-    global GraphQLArgumentType type {
-        get {
-            if (type == null) {
-                type = getArgumentTypeByValue(value);
-            }
-            return type;
-        }
-        private set;
-    }
+    global final GraphQLArgumentType type;
 
     /**
      * @description Create an instance of an argument by the provided name and value
@@ -47,6 +39,7 @@ global class GraphQLArgument {
     global GraphQLArgument(String key, Object value) {
         this.key = key;
         this.value = value;
+        this.type = getArgumentTypeByValue(value);
     }
 
     /**
@@ -57,55 +50,19 @@ global class GraphQLArgument {
         return value instanceof String && value != null && ((String) value).startsWith(GraphQLConstants.DOLLAR);
     }
 
-    /**
-     * @description Represents the current argument as a GraphQL enum value
-     * @throws GraphQLArgumentException If the current argument value is not String or if it's a variable reference
-     * @return The current instance of <<GraphQLArgument>>
-     */
-    global GraphQLArgument asEnum() {
-        if (!(value instanceof String) || isVariable()) {
-            throw new GraphQLArgumentException(
-                'Impossible to cast GraphQL argument as enum. The value type must be String and must not be a variable reference.'
-            );
-        }
-        type = GraphQLArgumentType.x_Enum;
-        return this;
-    }
-
     public override String toString() {
         return toString(false);
     }
 
     public String toString(Boolean pretty) {
         if (String.isBlank(key)) {
-            return valueToString(pretty);
+            return valueToString(value, pretty);
         }
-        return key + GraphQLConstants.COLON + GraphQLParser.getSmallIndent(pretty) + valueToString(pretty);
+        return key + GraphQLConstants.COLON + GraphQLParser.getSmallIndent(pretty) + valueToString(value, pretty);
     }
 
-    // There is no way to get an object's type yet
-    private GraphQLArgumentType getArgumentTypeByValue(Object value) {
-        if (value instanceof Integer || value instanceof Long) {
-            return GraphQLArgumentType.x_Integer;
-        } else if (value instanceof String || value instanceof Blob || value instanceof Id) {
-            return GraphQLArgumentType.x_String;
-        } else if (value instanceof Double || value instanceof Decimal) {
-            return GraphQLArgumentType.x_Float;
-        } else if (value instanceof Boolean) {
-            return GraphQLArgumentType.x_Boolean;
-        } else if (value instanceof Date) {
-            return GraphQLArgumentType.x_Date;
-        } else if (value instanceof DateTime || value instanceof Time) {
-            return GraphQLArgumentType.x_DateTime;
-        } else if (value == null) {
-            return GraphQLArgumentType.x_Null;
-        } else {
-            return GraphQLArgumentType.x_Object;
-        }
-    }
-
-    private String valueToString(Boolean pretty) {
-        switch on type {
+    private String valueToString(Object value, Boolean pretty) {
+        switch on getArgumentTypeByValue(value) {
             when x_Integer, x_Float, x_Boolean, x_Null, x_Enum {
                 return String.valueOf(value);
             }
@@ -124,14 +81,56 @@ global class GraphQLArgument {
                     dateToDateTime((Date) value).format(DATE_VALUE_FORMAT) +
                     GraphQLConstants.DOUBLE_QUOTES;
             }
+            when x_List {
+                return listToString((List<Object>) value, pretty);
+            }
             when else {
                 return objectToString(value, pretty);
             }
         }
     }
 
+    // There is no way to get an object's type yet
+    private GraphQLArgumentType getArgumentTypeByValue(Object value) {
+        if (value instanceof Integer || value instanceof Long) {
+            return GraphQLArgumentType.x_Integer;
+        } else if (value instanceof String || value instanceof Blob || value instanceof Id) {
+            return GraphQLArgumentType.x_String;
+        } else if (value instanceof Double || value instanceof Decimal) {
+            return GraphQLArgumentType.x_Float;
+        } else if (value instanceof Boolean) {
+            return GraphQLArgumentType.x_Boolean;
+        } else if (value instanceof Date) {
+            return GraphQLArgumentType.x_Date;
+        } else if (value instanceof DateTime || value instanceof Time) {
+            return GraphQLArgumentType.x_DateTime;
+        } else if (value instanceof GraphQLEnum) {
+            return GraphQLArgumentType.x_Enum;
+        } else if (value == null) {
+            return GraphQLArgumentType.x_Null;
+        } else if (value instanceof List<Object>) {
+            return GraphQLArgumentType.x_List;
+        } else {
+            return GraphQLArgumentType.x_Object;
+        }
+    }
+
     private DateTime dateToDateTime(Date dateValue) {
         return DateTime.newInstance(dateValue.year(), dateValue.month(), dateValue.day());
+    }
+
+    private String listToString(List<Object> elements, Boolean pretty) {
+        List<String> parsedElements = new List<String>();
+
+        for (Object element : elements) {
+            parsedElements.add(valueToString(element, pretty));
+        }
+
+        return GraphQLConstants.SQUARE_BRACE_LEFT +
+            GraphQLParser.getSmallIndent(pretty) +
+            String.join(parsedElements, GraphQLConstants.COMMA + GraphQLParser.getSmallIndent(pretty)) +
+            GraphQLParser.getSmallIndent(pretty) +
+            GraphQLConstants.SQUARE_BRACE_RIGHT;
     }
 
     private String objectToString(Object value, Boolean pretty) {
@@ -151,7 +150,4 @@ global class GraphQLArgument {
                 GraphQLConstants.COLON + GraphQLParser.getSmallIndent(pretty) + FIRST_REGEX_MATCH_GROUP
             );
     }
-
-    @TestVisible
-    private class GraphQLArgumentException extends Exception {}
 }

--- a/src/main/default/classes/nodes/arguments/GraphQLArgumentType.cls
+++ b/src/main/default/classes/nodes/arguments/GraphQLArgumentType.cls
@@ -9,6 +9,7 @@ global enum GraphQLArgumentType {
     x_DateTime,
     x_Date,
     x_Null,
+    x_List,
     x_Object,
     x_Enum
 }

--- a/src/main/default/classes/nodes/arguments/GraphQLEnum.cls
+++ b/src/main/default/classes/nodes/arguments/GraphQLEnum.cls
@@ -1,0 +1,21 @@
+/**
+ * @description Represents an enum value used in arguments and variables
+ */
+global class GraphQLEnum {
+    /**
+     * @description The enum value
+     */
+    global final String value;
+
+    /**
+     * @description Creates an instance of GraphQL enum by the provided enum value
+     * @param value The enum value
+     */
+    global GraphQLEnum(String value) {
+        this.value = value;
+    }
+
+    public override String toString() {
+        return value;
+    }
+}

--- a/src/main/default/classes/nodes/arguments/GraphQLEnum.cls-meta.xml
+++ b/src/main/default/classes/nodes/arguments/GraphQLEnum.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/main/default/classes/nodes/operations/GraphQLVariable.cls
+++ b/src/main/default/classes/nodes/operations/GraphQLVariable.cls
@@ -93,20 +93,6 @@ global class GraphQLVariable {
         return this;
     }
 
-    /**
-     * @description Represents the current variable default value as a GraphQL enum value
-     * @throws GraphQLVariableException If the doesn't have any default value set yet
-     * @throws GraphQLArgumentException If the default value is not String or if it's a variable reference
-     * @return The current instance of the variable definition
-     */
-    global GraphQLVariable asEnum() {
-        if (defaultValueArgument == null) {
-            throw new GraphQLVariableException('The default value was not set for the variable yet');
-        }
-        defaultValueArgument.asEnum();
-        return this;
-    }
-
     public override String toString() {
         return toString(false);
     }

--- a/src/test/classes/GraphQLArgumentTest.cls
+++ b/src/test/classes/GraphQLArgumentTest.cls
@@ -80,16 +80,6 @@ private class GraphQLArgumentTest {
     }
 
     @IsTest
-    private static void stringifyEnumArgumentTest() {
-        String key = 'key';
-        String value = 'VALUE';
-
-        GraphQLArgument argument = new GraphQLArgument(key, value).asEnum();
-
-        System.assertEquals('key:VALUE', argument.toString());
-    }
-
-    @IsTest
     private static void stringifyVariableArgumentTest() {
         String key = 'key';
         String value = '$variableName';
@@ -187,18 +177,37 @@ private class GraphQLArgumentTest {
     }
 
     @IsTest
-    private static void asEnumWithVariableFailureTest() {
+    private static void stringifyEnumArgumentTest() {
         String key = 'key';
-        String value = '$var';
+        GraphQLEnum value = new GraphQLEnum('VALUE');
 
-        Exception error;
-        try {
-            new GraphQLArgument(key, value).asEnum();
-        } catch (Exception ex) {
-            error = ex;
-        }
+        GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assert(error != null);
-        System.assert(error instanceof GraphQLArgument.GraphQLArgumentException);
+        Assert.areEqual('key:VALUE', argument.toString());
+        Assert.areEqual(argument.type, GraphQLArgumentType.x_Enum);
+    }
+
+    @IsTest
+    private static void stringifyEnumArrayArgumentTest() {
+        String key = 'key';
+        List<GraphQLEnum> value = new List<GraphQLEnum> { new GraphQLEnum('VALUE1'), new GraphQLEnum('VALUE2') };
+
+        GraphQLArgument argument = new GraphQLArgument(key, value);
+
+        Assert.areEqual('key:[VALUE1,VALUE2]', argument.toString());
+        Assert.areEqual('key: [ VALUE1, VALUE2 ]', argument.toString(true));
+        Assert.areEqual(argument.type, GraphQLArgumentType.x_List);
+    }
+
+    @IsTest
+    private static void stringifyStringArrayArgumentTest() {
+        String key = 'key';
+        List<String> value = new List<String> { 'value1', 'value2' };
+
+        GraphQLArgument argument = new GraphQLArgument(key, value);
+
+        Assert.areEqual('key:["value1","value2"]', argument.toString());
+        Assert.areEqual('key: [ "value1", "value2" ]', argument.toString(true));
+        Assert.areEqual(argument.type, GraphQLArgumentType.x_List);
     }
 }

--- a/src/test/classes/GraphQLArgumentTest.cls
+++ b/src/test/classes/GraphQLArgumentTest.cls
@@ -8,9 +8,9 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals(key, argument.key);
-        System.assertEquals(value, argument.value);
-        System.assertEquals(type, argument.type);
+        Assert.areEqual(key, argument.key);
+        Assert.areEqual(value, argument.value);
+        Assert.areEqual(type, argument.type);
     }
 
     @IsTest
@@ -20,13 +20,13 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:111', argument.toString());
+        Assert.areEqual('key:111', argument.toString());
     }
 
     @IsTest
     private static void stringifyIntegerArgumentWithoutKeyTest() {
         GraphQLArgument argument = new GraphQLArgument(null, 123);
-        System.assertEquals('123', argument.toString());
+        Assert.areEqual('123', argument.toString());
     }
 
     @IsTest
@@ -36,7 +36,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:1111111111', argument.toString());
+        Assert.areEqual('key:1111111111', argument.toString());
     }
 
     @IsTest
@@ -46,7 +46,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:111.11', argument.toString());
+        Assert.areEqual('key:111.11', argument.toString());
     }
 
     @IsTest
@@ -56,7 +56,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:111.11', argument.toString());
+        Assert.areEqual('key:111.11', argument.toString());
     }
 
     @IsTest
@@ -66,7 +66,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:true', argument.toString());
+        Assert.areEqual('key:true', argument.toString());
     }
 
     @IsTest
@@ -76,7 +76,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:"qqqq"', argument.toString());
+        Assert.areEqual('key:"qqqq"', argument.toString());
     }
 
     @IsTest
@@ -86,7 +86,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:$variableName', argument.toString());
+        Assert.areEqual('key:$variableName', argument.toString());
     }
 
     @IsTest
@@ -96,7 +96,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:"' + value + '"', argument.toString());
+        Assert.areEqual('key:"' + value + '"', argument.toString());
     }
 
     @IsTest
@@ -106,7 +106,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:"' + value + '"', argument.toString());
+        Assert.areEqual('key:"' + value + '"', argument.toString());
     }
 
     @IsTest
@@ -117,7 +117,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:"' + dateValue.format('MM/dd/yyyy') + '"', argument.toString());
+        Assert.areEqual('key:"' + dateValue.format('MM/dd/yyyy') + '"', argument.toString());
     }
 
     @IsTest
@@ -127,7 +127,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
-        System.assertEquals('key:"' + String.valueOf(value) + '"', argument.toString());
+        Assert.areEqual('key:"' + String.valueOf(value) + '"', argument.toString());
     }
 
     @IsTest
@@ -136,7 +136,7 @@ private class GraphQLArgumentTest {
 
         GraphQLArgument argument = new GraphQLArgument(key, null);
 
-        System.assertEquals('key:null', argument.toString());
+        Assert.areEqual('key:null', argument.toString());
     }
 
     @IsTest
@@ -152,7 +152,7 @@ private class GraphQLArgumentTest {
         GraphQLArgument argument = new GraphQLArgument(key, value);
 
         // Fields order is reversed
-        System.assertEquals(
+        Assert.areEqual(
             'key: { key4: { key42: "value:\\"$var2\\"     !", key41: $var2 }, key3: 2, key2: $var, key1: "value" }',
             argument.toString(true)
         );
@@ -170,7 +170,7 @@ private class GraphQLArgumentTest {
         GraphQLArgument argument = new GraphQLArgument(null, value);
 
         // Fields order is reversed
-        System.assertEquals(
+        Assert.areEqual(
             '{ key4: { key42: "value:\\"$var2\\"     !", key41: $var2 }, key3: 2, key2: $var, key1: "value" }',
             argument.toString(true)
         );

--- a/src/test/classes/GraphQLConfigsTest.cls
+++ b/src/test/classes/GraphQLConfigsTest.cls
@@ -10,8 +10,8 @@ private class GraphQLConfigsTest {
 
         String configValue = GraphQLConfigs.getString(config);
 
-        System.assert(configValue != null);
-        System.assertEquals('MM/dd/yyyy', configValue);
+        Assert.isNotNull(configValue);
+        Assert.areEqual('MM/dd/yyyy', configValue);
     }
 
     @IsTest
@@ -26,7 +26,7 @@ private class GraphQLConfigsTest {
             error = ex;
         }
 
-        System.assert(error != null);
-        System.assert(error.getMessage().startsWith('There is no such configuration entry'));
+        Assert.isNotNull(error != null);
+        Assert.isTrue(error.getMessage().startsWith('There is no such configuration entry'));
     }
 }

--- a/src/test/classes/GraphQLDirectiveTest.cls
+++ b/src/test/classes/GraphQLDirectiveTest.cls
@@ -3,30 +3,30 @@ private class GraphQLDirectiveTest {
     @IsTest
     private static void createDirectiveTest() {
         GraphQLDirective directive = new GraphQLDirective('test');
-        System.assertEquals('test', directive.name);
-        System.assert(!directive.hasArguments());
-        System.assertEquals('@test', directive.toString());
-        System.assertEquals('@test', directive.toString(true));
+        Assert.areEqual('test', directive.name);
+        Assert.isFalse(directive.hasArguments());
+        Assert.areEqual('@test', directive.toString());
+        Assert.areEqual('@test', directive.toString(true));
     }
 
     @IsTest
     private static void createDirectiveWithArgumentTest() {
         GraphQLDirective directive = new GraphQLDirective('include').withArgument('if', '$someVar');
 
-        System.assertEquals('include', directive.name);
-        System.assert(directive.hasArguments());
-        System.assertEquals('@include(if:$someVar)', directive.toString());
-        System.assertEquals('@include(if: $someVar)', directive.toString(true));
+        Assert.areEqual('include', directive.name);
+        Assert.isTrue(directive.hasArguments());
+        Assert.areEqual('@include(if:$someVar)', directive.toString());
+        Assert.areEqual('@include(if: $someVar)', directive.toString(true));
     }
 
     @IsTest
     private static void createDirectiveWithArgumentInstanceTest() {
         GraphQLDirective directive = new GraphQLDirective('include').withArgument(new GraphQLArgument('if', true));
 
-        System.assertEquals('include', directive.name);
-        System.assert(directive.hasArguments());
-        System.assertEquals('@include(if:true)', directive.toString());
-        System.assertEquals('@include(if: true)', directive.toString(true));
+        Assert.areEqual('include', directive.name);
+        Assert.isTrue(directive.hasArguments());
+        Assert.areEqual('@include(if:true)', directive.toString());
+        Assert.areEqual('@include(if: true)', directive.toString(true));
     }
 
     @IsTest
@@ -35,9 +35,9 @@ private class GraphQLDirectiveTest {
             .withArgument(new GraphQLArgument('if', '$someVar'))
             .withArgument(new GraphQLArgument('elseif', true));
 
-        System.assertEquals('test', directive.name);
-        System.assert(directive.hasArguments());
-        System.assertEquals('@test(if:$someVar,elseif:true)', directive.toString());
-        System.assertEquals('@test(if: $someVar, elseif: true)', directive.toString(true));
+        Assert.areEqual('test', directive.name);
+        Assert.isTrue(directive.hasArguments());
+        Assert.areEqual('@test(if:$someVar,elseif:true)', directive.toString());
+        Assert.areEqual('@test(if: $someVar, elseif: true)', directive.toString(true));
     }
 }

--- a/src/test/classes/GraphQLFieldTest.cls
+++ b/src/test/classes/GraphQLFieldTest.cls
@@ -4,10 +4,10 @@ private class GraphQLFieldTest {
     private static void emptyNodeTest() {
         GraphQLField node = new GraphQLField();
 
-        System.assert(node.isFieldNode());
-        System.assertEquals(GraphQLConstants.EMPTY, node.name);
-        System.assertEquals(0, node.nodes.size());
-        System.assertEquals(0, node.arguments.size());
+        Assert.isTrue(node.isFieldNode());
+        Assert.areEqual(GraphQLConstants.EMPTY, node.name);
+        Assert.areEqual(0, node.nodes.size());
+        Assert.areEqual(0, node.arguments.size());
     }
 
     @IsTest
@@ -16,9 +16,9 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField(nodeName);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(0, node.nodes.size());
-        System.assertEquals(0, node.arguments.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(0, node.nodes.size());
+        Assert.areEqual(0, node.arguments.size());
     }
 
     @IsTest
@@ -27,11 +27,11 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField(childNodes);
 
-        System.assertEquals(GraphQLConstants.EMPTY, node.name);
-        System.assertEquals(childNodes.size(), node.nodes.size());
-        System.assertEquals(0, node.arguments.size());
-        System.assert(node.hasField(childNodes.get(0)));
-        System.assert(!node.hasField(new GraphQLField('node3')));
+        Assert.areEqual(GraphQLConstants.EMPTY, node.name);
+        Assert.areEqual(childNodes.size(), node.nodes.size());
+        Assert.areEqual(0, node.arguments.size());
+        Assert.isTrue(node.hasField(childNodes.get(0)));
+        Assert.isFalse(node.hasField(new GraphQLField('node3')));
     }
 
     @IsTest
@@ -41,9 +41,9 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField(nodeName, childNodes);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(childNodes.size(), node.nodes.size());
-        System.assertEquals(0, node.arguments.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(childNodes.size(), node.nodes.size());
+        Assert.areEqual(0, node.arguments.size());
     }
 
     @IsTest
@@ -52,9 +52,9 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField(fields);
 
-        System.assertEquals(GraphQLConstants.EMPTY, node.name);
-        System.assertEquals(fields.size(), node.nodes.size());
-        System.assertEquals(0, node.arguments.size());
+        Assert.areEqual(GraphQLConstants.EMPTY, node.name);
+        Assert.areEqual(fields.size(), node.nodes.size());
+        Assert.areEqual(0, node.arguments.size());
     }
 
     @IsTest
@@ -64,9 +64,9 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField(nodeName, fields);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(fields.size(), node.nodes.size());
-        System.assertEquals(0, node.arguments.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(fields.size(), node.nodes.size());
+        Assert.areEqual(0, node.arguments.size());
     }
 
     @IsTest
@@ -75,8 +75,8 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField().withField(fieldName);
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals(fieldName, node.nodes.get(0).name);
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual(fieldName, node.nodes.get(0).name);
     }
 
     @IsTest
@@ -85,9 +85,9 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField().withFields(fields);
 
-        System.assertEquals(fields.size(), node.nodes.size());
-        System.assertEquals('field1', node.nodes.get(0).name);
-        System.assertEquals('field2', node.nodes.get(1).name);
+        Assert.areEqual(fields.size(), node.nodes.size());
+        Assert.areEqual('field1', node.nodes.get(0).name);
+        Assert.areEqual('field2', node.nodes.get(1).name);
     }
 
     @IsTest
@@ -96,8 +96,8 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField().withFragment(fragmentName);
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals(GraphQLConstants.DOT.repeat(3) + fragmentName, node.nodes.get(0).name);
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual(GraphQLConstants.DOT.repeat(3) + fragmentName, node.nodes.get(0).name);
     }
 
     @IsTest
@@ -106,9 +106,9 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField().withFragments(fragments);
 
-        System.assertEquals(fragments.size(), node.nodes.size());
-        System.assertEquals(GraphQLConstants.DOT.repeat(3) + 'FieldSet1', node.nodes.get(0).name);
-        System.assertEquals(GraphQLConstants.DOT.repeat(3) + 'FieldSet12', node.nodes.get(1).name);
+        Assert.areEqual(fragments.size(), node.nodes.size());
+        Assert.areEqual(GraphQLConstants.DOT.repeat(3) + 'FieldSet1', node.nodes.get(0).name);
+        Assert.areEqual(GraphQLConstants.DOT.repeat(3) + 'FieldSet12', node.nodes.get(1).name);
     }
 
     @IsTest
@@ -117,9 +117,9 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField().withInlineFragment(fragment);
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals('{... on SomeType{field1}}', node.build());
-        System.assertEquals('{\n  ... on SomeType {\n    field1\n  }\n}', node.build(true));
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual('{... on SomeType{field1}}', node.build());
+        Assert.areEqual('{\n  ... on SomeType {\n    field1\n  }\n}', node.build(true));
     }
 
     @IsTest
@@ -131,8 +131,8 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField().withInlineFragments(fragments);
 
-        System.assertEquals(2, node.nodes.size());
-        System.assertEquals('{... on SomeType{field1},... on SomeType2{field11}}', node.build());
+        Assert.areEqual(2, node.nodes.size());
+        Assert.areEqual('{... on SomeType{field1},... on SomeType2{field11}}', node.build());
     }
 
     @IsTest
@@ -140,9 +140,9 @@ private class GraphQLFieldTest {
         GraphQLField node = new GraphQLField()
             .withInlineFragment(new GraphQLFragment().withField('field1').withField('field2'));
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals('{...{field1,field2}}', node.build());
-        System.assertEquals('{\n  ... {\n    field1\n    field2\n  }\n}', node.build(true));
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual('{...{field1,field2}}', node.build());
+        Assert.areEqual('{\n  ... {\n    field1\n    field2\n  }\n}', node.build(true));
     }
 
     @IsTest
@@ -156,8 +156,8 @@ private class GraphQLFieldTest {
             error = ex;
         }
 
-        System.assert(error != null);
-        System.assert(error instanceof GraphQLNode.GraphQLNodeException);
+        Assert.isNotNull(error);
+        Assert.isInstanceOfType(error, GraphQLNode.GraphQLNodeException.class);
     }
 
     @IsTest
@@ -166,8 +166,8 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField().withField(new GraphQLField(nodeName));
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals(nodeName, node.nodes.get(0).name);
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual(nodeName, node.nodes.get(0).name);
     }
 
     @IsTest
@@ -176,17 +176,17 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField().withFields(nodes);
 
-        System.assertEquals(nodes.size(), node.nodes.size());
-        System.assertEquals('node1', node.nodes.get(0).name);
-        System.assertEquals('node2', node.nodes.get(1).name);
+        Assert.areEqual(nodes.size(), node.nodes.size());
+        Assert.areEqual('node1', node.nodes.get(0).name);
+        Assert.areEqual('node2', node.nodes.get(1).name);
     }
 
     @IsTest
     private static void nodeWithArgumentTest() {
         GraphQLField node = new GraphQLField().withArgument('key', 'value');
 
-        System.assertEquals(1, node.arguments.size());
-        System.assertEquals('value', node.arguments.get('key').value);
+        Assert.areEqual(1, node.arguments.size());
+        Assert.areEqual('value', node.arguments.get('key').value);
     }
 
     @IsTest
@@ -198,9 +198,9 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField().withArguments(arguments);
 
-        System.assertEquals(arguments.size(), node.arguments.size());
-        System.assertEquals('value1', node.arguments.get('key1').value);
-        System.assertEquals('value2', node.arguments.get('key2').value);
+        Assert.areEqual(arguments.size(), node.arguments.size());
+        Assert.areEqual('value1', node.arguments.get('key1').value);
+        Assert.areEqual('value2', node.arguments.get('key2').value);
     }
 
     @IsTest
@@ -209,26 +209,26 @@ private class GraphQLFieldTest {
             .withDirective(new GraphQLDirective('test').withArgument('var', true))
             .withField('field1');
 
-        System.assert(node.hasDirectives());
-        System.assertEquals(1, node.directives.size());
-        System.assertEquals('node@test(var:true){field1}', node.build());
-        System.assertEquals('node @test(var: true) {\n  field1\n}', node.build(true));
+        Assert.isTrue(node.hasDirectives());
+        Assert.areEqual(1, node.directives.size());
+        Assert.areEqual('node@test(var:true){field1}', node.build());
+        Assert.areEqual('node @test(var: true) {\n  field1\n}', node.build(true));
     }
 
     @IsTest
     private static void nodeIncludeIfConditionAndVariableTest() {
         GraphQLField node = new GraphQLField().includeIf(false).includeIf('var');
 
-        System.assert(node.hasDirectives());
-        System.assertEquals(2, node.directives.size());
+        Assert.isTrue(node.hasDirectives());
+        Assert.areEqual(2, node.directives.size());
     }
 
     @IsTest
     private static void nodeSkipIfConditionAndVariableTest() {
         GraphQLField node = new GraphQLField().skipIf(false).skipIf('var');
 
-        System.assert(node.hasDirectives());
-        System.assertEquals(2, node.directives.size());
+        Assert.isTrue(node.hasDirectives());
+        Assert.areEqual(2, node.directives.size());
     }
 
     @IsTest
@@ -237,10 +237,10 @@ private class GraphQLFieldTest {
 
         GraphQLQuery query = new GraphQLField('Test', nodes).asQuery();
 
-        System.assertEquals('Test', query.name);
-        System.assertEquals(nodes.size(), query.nodes.size());
-        System.assertEquals(0, query.variables.size());
-        System.assertEquals('query Test{node1,node2}', query.toString());
+        Assert.areEqual('Test', query.name);
+        Assert.areEqual(nodes.size(), query.nodes.size());
+        Assert.areEqual(0, query.variables.size());
+        Assert.areEqual('query Test{node1,node2}', query.toString());
     }
 
     @IsTest
@@ -249,10 +249,10 @@ private class GraphQLFieldTest {
 
         GraphQLMutation mutation = new GraphQLField('Test', nodes).asMutation();
 
-        System.assertEquals('Test', mutation.name);
-        System.assertEquals(nodes.size(), mutation.nodes.size());
-        System.assertEquals(0, mutation.variables.size());
-        System.assertEquals('mutation Test{node1,node2}', mutation.toString());
+        Assert.areEqual('Test', mutation.name);
+        Assert.areEqual(nodes.size(), mutation.nodes.size());
+        Assert.areEqual(0, mutation.variables.size());
+        Assert.areEqual('mutation Test{node1,node2}', mutation.toString());
     }
 
     @IsTest
@@ -261,10 +261,10 @@ private class GraphQLFieldTest {
 
         GraphQLSubscription subscription = new GraphQLField('Test', nodes).asSubscription();
 
-        System.assertEquals('Test', subscription.name);
-        System.assertEquals(nodes.size(), subscription.nodes.size());
-        System.assertEquals(0, subscription.variables.size());
-        System.assertEquals('subscription Test{node1,node2}', subscription.toString());
+        Assert.areEqual('Test', subscription.name);
+        Assert.areEqual(nodes.size(), subscription.nodes.size());
+        Assert.areEqual(0, subscription.variables.size());
+        Assert.areEqual('subscription Test{node1,node2}', subscription.toString());
     }
 
     /**
@@ -277,9 +277,8 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField(new List<GraphQLField> { childNode });
 
-        System.assert(node != null);
-        System.assertEquals('{ctrs:countries{name,code}}', node.build());
-        System.assertEquals('{\n  ctrs: countries {\n    name\n    code\n  }\n}', node.build(true));
+        Assert.areEqual('{ctrs:countries{name,code}}', node.build());
+        Assert.areEqual('{\n  ctrs: countries {\n    name\n    code\n  }\n}', node.build(true));
     }
 
     @IsTest
@@ -288,11 +287,10 @@ private class GraphQLFieldTest {
 
         GraphQLField node = new GraphQLField().withFields(fields).withFragment('SomeFields');
 
-        System.assert(node != null);
-        System.assertEquals(GraphQLConstants.EMPTY, node.name);
-        System.assertEquals(fields.size() + 1, node.nodes.size());
-        System.assertEquals('{field1,field2,field3,...SomeFields}', node.build());
-        System.assertEquals('{\n  field1\n  field2\n  field3\n  ...SomeFields\n}', node.build(true));
+        Assert.areEqual(GraphQLConstants.EMPTY, node.name);
+        Assert.areEqual(fields.size() + 1, node.nodes.size());
+        Assert.areEqual('{field1,field2,field3,...SomeFields}', node.build());
+        Assert.areEqual('{\n  field1\n  field2\n  field3\n  ...SomeFields\n}', node.build(true));
     }
 
     @IsTest
@@ -304,10 +302,9 @@ private class GraphQLFieldTest {
             .withFragment('SomeFields')
             .withInlineFragment(inlineFragment);
 
-        System.assert(node != null);
-        System.assertEquals(3, node.nodes.size());
-        System.assertEquals('{field1,...SomeFields,... on SomeType{field11}}', node.build());
-        System.assertEquals('{\n  field1\n  ...SomeFields\n  ... on SomeType {\n    field11\n  }\n}', node.build(true));
+        Assert.areEqual(3, node.nodes.size());
+        Assert.areEqual('{field1,...SomeFields,... on SomeType{field11}}', node.build());
+        Assert.areEqual('{\n  field1\n  ...SomeFields\n  ... on SomeType {\n    field11\n  }\n}', node.build(true));
     }
 
     @IsTest
@@ -316,11 +313,10 @@ private class GraphQLFieldTest {
 
         GraphQLQuery query = new GraphQLField().withFields(fields).withArgument('arg', 'value').asQuery();
 
-        System.assert(query != null);
-        System.assert(String.isBlank(query.name));
-        System.assertEquals(fields.size(), query.nodes.size());
-        System.assertEquals('query{field1,field2,field3}', query.build());
-        System.assertEquals('query {\n  field1\n  field2\n  field3\n}', query.build(true));
+        Assert.isTrue(String.isBlank(query.name));
+        Assert.areEqual(fields.size(), query.nodes.size());
+        Assert.areEqual('query{field1,field2,field3}', query.build());
+        Assert.areEqual('query {\n  field1\n  field2\n  field3\n}', query.build(true));
     }
 
     @IsTest
@@ -329,11 +325,10 @@ private class GraphQLFieldTest {
 
         GraphQLMutation mutation = new GraphQLField().withFields(fields).withArgument('arg', 'value').asMutation();
 
-        System.assert(mutation != null);
-        System.assert(String.isBlank(mutation.name));
-        System.assertEquals(fields.size(), mutation.nodes.size());
-        System.assertEquals('mutation{field1,field2,field3}', mutation.build());
-        System.assertEquals('mutation {\n  field1\n  field2\n  field3\n}', mutation.build(true));
+        Assert.isTrue(String.isBlank(mutation.name));
+        Assert.areEqual(fields.size(), mutation.nodes.size());
+        Assert.areEqual('mutation{field1,field2,field3}', mutation.build());
+        Assert.areEqual('mutation {\n  field1\n  field2\n  field3\n}', mutation.build(true));
     }
 
     @IsTest
@@ -345,11 +340,10 @@ private class GraphQLFieldTest {
             .withArgument('arg', 'value')
             .asSubscription();
 
-        System.assert(subscription != null);
-        System.assert(String.isBlank(subscription.name));
-        System.assertEquals(fields.size(), subscription.nodes.size());
-        System.assertEquals('subscription{field1,field2,field3}', subscription.build());
-        System.assertEquals('subscription {\n  field1\n  field2\n  field3\n}', subscription.build(true));
+        Assert.isTrue(String.isBlank(subscription.name));
+        Assert.areEqual(fields.size(), subscription.nodes.size());
+        Assert.areEqual('subscription{field1,field2,field3}', subscription.build());
+        Assert.areEqual('subscription {\n  field1\n  field2\n  field3\n}', subscription.build(true));
     }
 
     @IsTest
@@ -370,20 +364,14 @@ private class GraphQLFieldTest {
 
         GraphQLField rootNode = new GraphQLField(childrenNodes);
 
-        System.assert(firstNode != null);
-        System.assert(secondNode != null);
-        System.assert(rootNode != null);
-        System.assertEquals(firstMethodName, firstNode.name);
-        System.assertEquals(secondMethodName, secondNode.name);
-        System.assertEquals(GraphQLConstants.EMPTY, rootNode.name);
-        System.assertEquals(firstMethodFields.size(), firstNode.nodes.size());
-        System.assertEquals(secondMethodFields.size(), secondNode.nodes.size());
-        System.assertEquals(childrenNodes.size(), rootNode.nodes.size());
-        System.assertEquals(
-            '{testMethod1{field1,field2},testMethod2{field3{field11,field22},field4}}',
-            rootNode.build()
-        );
-        System.assertEquals(
+        Assert.areEqual(firstMethodName, firstNode.name);
+        Assert.areEqual(secondMethodName, secondNode.name);
+        Assert.areEqual(GraphQLConstants.EMPTY, rootNode.name);
+        Assert.areEqual(firstMethodFields.size(), firstNode.nodes.size());
+        Assert.areEqual(secondMethodFields.size(), secondNode.nodes.size());
+        Assert.areEqual(childrenNodes.size(), rootNode.nodes.size());
+        Assert.areEqual('{testMethod1{field1,field2},testMethod2{field3{field11,field22},field4}}', rootNode.build());
+        Assert.areEqual(
             '{\n  testMethod1 {\n    field1\n    field2\n  }\n  testMethod2 {\n    field3 {\n      field11\n      field22\n    }\n    field4\n  }\n}',
             rootNode.build(true)
         );
@@ -401,15 +389,13 @@ private class GraphQLFieldTest {
 
         GraphQLField rootNode = new GraphQLField('root').withField(node);
 
-        System.assert(node != null);
-        System.assert(rootNode != null);
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(fields.size(), node.nodes.size());
-        System.assertEquals(
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(fields.size(), node.nodes.size());
+        Assert.areEqual(
             'root{testMethod(var1:"test1",var2:1,var3:{f3:$ref,f2:"2",f1:1}){field1,field2,field3}}',
             rootNode.build()
         );
-        System.assertEquals(
+        Assert.areEqual(
             'root {\n  testMethod(var1: "test1", var2: 1, var3: { f3: $ref, f2: "2", f1: 1 }) {\n    field1\n    field2\n    field3\n  }\n}',
             rootNode.build(true)
         );
@@ -427,11 +413,11 @@ private class GraphQLFieldTest {
 
         GraphQLField rootNode = new GraphQLField('root').withField(node);
 
-        System.assertEquals(
+        Assert.areEqual(
             'root{testMethod(var1:$test1)@include(if:true) @skip(if:$test1){field1,field2,field3}}',
             rootNode.build()
         );
-        System.assertEquals(
+        Assert.areEqual(
             'root {\n  testMethod(var1: $test1) @include(if: true) @skip(if: $test1) {\n    field1\n    field2\n    field3\n  }\n}',
             rootNode.build(true)
         );
@@ -458,8 +444,8 @@ private class GraphQLFieldTest {
             error = err;
         }
 
-        System.assert(error != null);
-        System.assert(error.getMessage().startsWith('Maximum request depth level is'));
+        Assert.isNotNull(error);
+        Assert.isTrue(error.getMessage().startsWith('Maximum request depth level is'));
     }
 
     @IsTest
@@ -473,8 +459,8 @@ private class GraphQLFieldTest {
             error = err;
         }
 
-        System.assert(error != null);
-        System.assertEquals('Cannot parse an empty node without any child nodes', error.getMessage());
+        Assert.isNotNull(error);
+        Assert.areEqual('Cannot parse an empty node without any child nodes', error.getMessage());
     }
 
     @IsTest
@@ -486,8 +472,8 @@ private class GraphQLFieldTest {
             error = ex;
         }
 
-        System.assert(error != null);
-        System.assert(error instanceof GraphQLNode.GraphQLNodeException);
+        Assert.isNotNull(error);
+        Assert.isInstanceOfType(error, GraphQLNode.GraphQLNodeException.class);
     }
 
     private class TestNode extends GraphQLNode {

--- a/src/test/classes/GraphQLFragmentTest.cls
+++ b/src/test/classes/GraphQLFragmentTest.cls
@@ -6,10 +6,10 @@ private class GraphQLFragmentTest {
         String type = 'SomeType';
         GraphQLFragment fragment = new GraphQLFragment(name, type);
 
-        System.assert(fragment.isFragmentNode());
-        System.assertEquals(name, fragment.name);
-        System.assertEquals(type, fragment.type);
-        System.assert(!fragment.hasNodes());
+        Assert.isTrue(fragment.isFragmentNode());
+        Assert.areEqual(name, fragment.name);
+        Assert.areEqual(type, fragment.type);
+        Assert.isFalse(fragment.hasNodes());
     }
 
     @IsTest
@@ -19,10 +19,10 @@ private class GraphQLFragmentTest {
         List<String> fields = new List<String> { 'field1', 'field2', 'field3' };
         GraphQLFragment fragment = new GraphQLFragment(name, type, fields);
 
-        System.assertEquals(name, fragment.name);
-        System.assertEquals(type, fragment.type);
-        System.assert(fragment.hasNodes());
-        System.assertEquals(fields.size(), fragment.nodes.size());
+        Assert.areEqual(name, fragment.name);
+        Assert.areEqual(type, fragment.type);
+        Assert.isTrue(fragment.hasNodes());
+        Assert.areEqual(fields.size(), fragment.nodes.size());
     }
 
     @IsTest
@@ -35,10 +35,10 @@ private class GraphQLFragmentTest {
         };
         GraphQLFragment fragment = new GraphQLFragment(name, type, nodes);
 
-        System.assertEquals(name, fragment.name);
-        System.assertEquals(type, fragment.type);
-        System.assert(fragment.hasNodes());
-        System.assertEquals(nodes.size(), fragment.nodes.size());
+        Assert.areEqual(name, fragment.name);
+        Assert.areEqual(type, fragment.type);
+        Assert.isTrue(fragment.hasNodes());
+        Assert.areEqual(nodes.size(), fragment.nodes.size());
     }
 
     @IsTest
@@ -52,10 +52,10 @@ private class GraphQLFragmentTest {
         List<String> fields = new List<String> { 'field1', 'field2', 'field3' };
         GraphQLFragment fragment = new GraphQLFragment(name, type, nodes, fields);
 
-        System.assertEquals(name, fragment.name);
-        System.assertEquals(type, fragment.type);
-        System.assert(fragment.hasNodes());
-        System.assertEquals(nodes.size() + fields.size(), fragment.nodes.size());
+        Assert.areEqual(name, fragment.name);
+        Assert.areEqual(type, fragment.type);
+        Assert.isTrue(fragment.hasNodes());
+        Assert.areEqual(nodes.size() + fields.size(), fragment.nodes.size());
     }
 
     @IsTest
@@ -64,10 +64,10 @@ private class GraphQLFragmentTest {
         String type = 'SomeType';
         GraphQLFragment fragment = new GraphQLFragment(name, type).withField('field1');
 
-        System.assertEquals(name, fragment.name);
-        System.assertEquals(type, fragment.type);
-        System.assert(fragment.hasNodes());
-        System.assertEquals(1, fragment.nodes.size());
+        Assert.areEqual(name, fragment.name);
+        Assert.areEqual(type, fragment.type);
+        Assert.isTrue(fragment.hasNodes());
+        Assert.areEqual(1, fragment.nodes.size());
     }
 
     @IsTest
@@ -77,10 +77,10 @@ private class GraphQLFragmentTest {
         GraphQLFragment fragment = new GraphQLFragment(name, type)
             .withField(new GraphQLField('node', new List<String> { 'field1', 'field2' }));
 
-        System.assertEquals(name, fragment.name);
-        System.assertEquals(type, fragment.type);
-        System.assert(fragment.hasNodes());
-        System.assertEquals(1, fragment.nodes.size());
+        Assert.areEqual(name, fragment.name);
+        Assert.areEqual(type, fragment.type);
+        Assert.isTrue(fragment.hasNodes());
+        Assert.areEqual(1, fragment.nodes.size());
     }
 
     @IsTest
@@ -89,10 +89,10 @@ private class GraphQLFragmentTest {
         String type = 'SomeType';
         GraphQLFragment fragment = new GraphQLFragment(name, type).withFragment('OtherFields');
 
-        System.assertEquals(name, fragment.name);
-        System.assertEquals(type, fragment.type);
-        System.assert(fragment.hasNodes());
-        System.assertEquals(1, fragment.nodes.size());
+        Assert.areEqual(name, fragment.name);
+        Assert.areEqual(type, fragment.type);
+        Assert.isTrue(fragment.hasNodes());
+        Assert.areEqual(1, fragment.nodes.size());
     }
 
     @IsTest
@@ -105,15 +105,15 @@ private class GraphQLFragmentTest {
             .withDirective(new GraphQLDirective('include').withArgument('if', true))
             .withDirective(new GraphQLDirective('skip').withArgument('if', false));
 
-        System.assert(fragment.hasNodes());
-        System.assert(fragment.hasDirectives());
-        System.assertEquals(2, fragment.nodes.size());
-        System.assertEquals(2, fragment.directives.size());
-        System.assertEquals(
+        Assert.isTrue(fragment.hasNodes());
+        Assert.isTrue(fragment.hasDirectives());
+        Assert.areEqual(2, fragment.nodes.size());
+        Assert.areEqual(2, fragment.directives.size());
+        Assert.areEqual(
             'fragment Fields on SomeType@include(if:true) @skip(if:false){field1,field2}',
             fragment.build()
         );
-        System.assertEquals(
+        Assert.areEqual(
             'fragment Fields on SomeType @include(if: true) @skip(if: false) {\n  field1\n  field2\n}',
             fragment.build(true)
         );
@@ -129,15 +129,15 @@ private class GraphQLFragmentTest {
             .includeIf(true)
             .skipIf(false);
 
-        System.assert(fragment.hasNodes());
-        System.assert(fragment.hasDirectives());
-        System.assertEquals(2, fragment.nodes.size());
-        System.assertEquals(2, fragment.directives.size());
-        System.assertEquals(
+        Assert.isTrue(fragment.hasNodes());
+        Assert.isTrue(fragment.hasDirectives());
+        Assert.areEqual(2, fragment.nodes.size());
+        Assert.areEqual(2, fragment.directives.size());
+        Assert.areEqual(
             'fragment Fields on SomeType@include(if:true) @skip(if:false){field1,field2}',
             fragment.build()
         );
-        System.assertEquals(
+        Assert.areEqual(
             'fragment Fields on SomeType @include(if: true) @skip(if: false) {\n  field1\n  field2\n}',
             fragment.build(true)
         );
@@ -148,8 +148,8 @@ private class GraphQLFragmentTest {
         GraphQLFragment inlineFragment = new GraphQLFragment('SomeType2').withField('field1');
         GraphQLFragment fragment = new GraphQLFragment('Fields', 'SomeType').withInlineFragment(inlineFragment);
 
-        System.assert(fragment.hasNodes());
-        System.assertEquals(1, fragment.nodes.size());
+        Assert.isTrue(fragment.hasNodes());
+        Assert.areEqual(1, fragment.nodes.size());
     }
 
     /**
@@ -166,11 +166,11 @@ private class GraphQLFragmentTest {
             .withInlineFragment(new GraphQLFragment('SomeType2').withField('field11'))
             .withInlineFragment(new GraphQLFragment().includeIf('var').skipIf('var2').withField('field22'));
 
-        System.assertEquals(
+        Assert.areEqual(
             'fragment Fields on SomeType{field1,field2,node{field1,field2},... on SomeType2{field11},...@include(if:$var) @skip(if:$var2){field22}}',
             fragment.build()
         );
-        System.assertEquals(
+        Assert.areEqual(
             'fragment Fields on SomeType {\n  field1\n  field2\n  node {\n    field1\n    field2\n  }\n  ... on SomeType2 {\n    field11\n  }\n  ... @include(if: $var) @skip(if: $var2) {\n    field22\n  }\n}',
             fragment.build(true)
         );

--- a/src/test/classes/GraphQLHttpClientTest.cls
+++ b/src/test/classes/GraphQLHttpClientTest.cls
@@ -11,8 +11,8 @@ private class GraphQLHttpClientTest {
             error = ex;
         }
 
-        System.assert(error != null);
-        System.assert(error instanceof GraphQLHttpClient.GraphQLHttpClientException);
+        Assert.isNotNull(error);
+        Assert.isInstanceOfType(error, GraphQLHttpClient.GraphQLHttpClientException.class);
     }
 
     /**
@@ -33,14 +33,14 @@ private class GraphQLHttpClientTest {
         GraphQLResponse response = client.send(request);
         Test.stopTest();
 
-        System.assert(!response.hasErrors());
-        System.assert(response.hasData());
+        Assert.isFalse(response.hasErrors());
+        Assert.isTrue(response.hasData());
 
         HeroWrapper hero = (HeroWrapper) response.getDataNodeAs('hero', HeroWrapper.class);
 
-        System.assertEquals(null, hero.id);
-        System.assertEquals('R2-D2', hero.name);
-        System.assertEquals(2, hero.heroFriends.size());
+        Assert.isNull(hero.id);
+        Assert.areEqual('R2-D2', hero.name);
+        Assert.areEqual(2, hero.heroFriends.size());
     }
 
     @IsTest
@@ -57,13 +57,13 @@ private class GraphQLHttpClientTest {
         GraphQLResponse response = client.send(request);
         Test.stopTest();
 
-        System.assert(response.hasErrors());
-        System.assert(!response.hasData());
+        Assert.isTrue(response.hasErrors());
+        Assert.isFalse(response.hasData());
 
         List<GraphQLResponseError> errors = response.getErrors();
 
-        System.assertEquals(1, errors.size());
-        System.assert(errors.get(0).message.startsWith('Got invalid response format from the server'));
+        Assert.areEqual(1, errors.size());
+        Assert.isTrue(errors.get(0).message.startsWith('Got invalid response format from the server'));
     }
 
     @IsTest
@@ -80,7 +80,7 @@ private class GraphQLHttpClientTest {
         Id jobId = client.sendAsync(request, new AsyncResponseCallback());
         Test.stopTest();
 
-        System.assert(jobId != null);
+        Assert.isNotNull(jobId);
     }
 
     private class HeroWrapper {
@@ -91,15 +91,15 @@ private class GraphQLHttpClientTest {
 
     private class AsyncResponseCallback implements IGraphQLResponseCallback {
         public void received(GraphQLResponse response) {
-            System.assert(response != null);
-            System.assert(!response.hasErrors());
-            System.assert(response.hasData());
+            Assert.isNotNull(response);
+            Assert.isFalse(response.hasErrors());
+            Assert.isTrue(response.hasData());
 
             HeroWrapper hero = (HeroWrapper) response.getDataNodeAs('hero', HeroWrapper.class);
 
-            System.assertEquals(null, hero.id);
-            System.assertEquals('R2-D2', hero.name);
-            System.assertEquals(2, hero.heroFriends.size());
+            Assert.isNull(hero.id);
+            Assert.areEqual('R2-D2', hero.name);
+            Assert.areEqual(2, hero.heroFriends.size());
         }
     }
 

--- a/src/test/classes/GraphQLMutationTest.cls
+++ b/src/test/classes/GraphQLMutationTest.cls
@@ -4,8 +4,8 @@ private class GraphQLMutationTest {
     private static void emptyMutationTest() {
         GraphQLMutation node = new GraphQLMutation();
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(0, node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(0, node.nodes.size());
     }
 
     @IsTest
@@ -14,8 +14,8 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation(nodeName);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(0, node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(0, node.nodes.size());
     }
 
     @IsTest
@@ -24,8 +24,8 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation(childNode);
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(1, node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(1, node.nodes.size());
     }
 
     @IsTest
@@ -34,8 +34,8 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation(childNodes);
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(childNodes.size(), node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(childNodes.size(), node.nodes.size());
     }
 
     @IsTest
@@ -44,8 +44,8 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation(nodeName, new GraphQLField('node1'));
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(1, node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(1, node.nodes.size());
     }
 
     @IsTest
@@ -55,8 +55,8 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation(nodeName, childNodes);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(childNodes.size(), node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(childNodes.size(), node.nodes.size());
     }
 
     @IsTest
@@ -65,8 +65,8 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation(fields);
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(fields.size(), node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(fields.size(), node.nodes.size());
     }
 
     @IsTest
@@ -76,8 +76,8 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation(nodeName, fields);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(fields.size(), node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(fields.size(), node.nodes.size());
     }
 
     @IsTest
@@ -86,8 +86,8 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation().withField(fieldName);
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals(fieldName, node.nodes.get(0).name);
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual(fieldName, node.nodes.get(0).name);
     }
 
     @IsTest
@@ -96,9 +96,9 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation().withFields(fields);
 
-        System.assertEquals(fields.size(), node.nodes.size());
-        System.assertEquals('field1', node.nodes.get(0).name);
-        System.assertEquals('field2', node.nodes.get(1).name);
+        Assert.areEqual(fields.size(), node.nodes.size());
+        Assert.areEqual('field1', node.nodes.get(0).name);
+        Assert.areEqual('field2', node.nodes.get(1).name);
     }
 
     @IsTest
@@ -107,9 +107,9 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation().defineFragment(fragment);
 
-        System.assert(node.hasFragments());
-        System.assertEquals(1, node.fragments.size());
-        System.assertEquals(fragment.name, node.fragments.get(0).name);
+        Assert.isTrue(node.hasFragments());
+        Assert.areEqual(1, node.fragments.size());
+        Assert.areEqual(fragment.name, node.fragments.get(0).name);
     }
 
     @IsTest
@@ -121,19 +121,19 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation().defineFragments(fragments);
 
-        System.assert(node.hasFragments());
-        System.assertEquals(fragments.size(), node.fragments.size());
-        System.assertEquals('fragment1', node.fragments.get(0).name);
-        System.assertEquals('fragment2', node.fragments.get(1).name);
+        Assert.isTrue(node.hasFragments());
+        Assert.areEqual(fragments.size(), node.fragments.size());
+        Assert.areEqual('fragment1', node.fragments.get(0).name);
+        Assert.areEqual('fragment2', node.fragments.get(1).name);
     }
 
     @IsTest
     private static void mutationWithDirectiveTest() {
         GraphQLMutation mutation = new GraphQLMutation().withDirective(new GraphQLDirective('test')).withField('field');
 
-        System.assertEquals(1, mutation.directives.size());
-        System.assertEquals('mutation@test{field}', mutation.build());
-        System.assertEquals('mutation @test {\n  field\n}', mutation.build(true));
+        Assert.areEqual(1, mutation.directives.size());
+        Assert.areEqual('mutation@test{field}', mutation.build());
+        Assert.areEqual('mutation @test {\n  field\n}', mutation.build(true));
     }
 
     @IsTest
@@ -142,8 +142,8 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation().withField(new GraphQLField(nodeName));
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals(nodeName, node.nodes.get(0).name);
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual(nodeName, node.nodes.get(0).name);
     }
 
     @IsTest
@@ -152,9 +152,9 @@ private class GraphQLMutationTest {
 
         GraphQLMutation node = new GraphQLMutation().withFields(nodes);
 
-        System.assertEquals(nodes.size(), node.nodes.size());
-        System.assertEquals('node1', node.nodes.get(0).name);
-        System.assertEquals('node2', node.nodes.get(1).name);
+        Assert.areEqual(nodes.size(), node.nodes.size());
+        Assert.areEqual('node1', node.nodes.get(0).name);
+        Assert.areEqual('node2', node.nodes.get(1).name);
     }
 
     @IsTest
@@ -163,16 +163,16 @@ private class GraphQLMutationTest {
             .withField(new GraphQLField('node'))
             .defineVariable('var', '[String!]');
 
-        System.assertEquals(1, node.variables.size());
+        Assert.areEqual(1, node.variables.size());
     }
 
     @IsTest
     private static void mutationBuildRequestTest() {
         GraphQLRequest request = new GraphQLMutation(new List<String> { 'field1' }).asRequest();
 
-        System.assertEquals(GraphQLOperationType.Mutation, request.operation);
-        System.assertEquals('{"query":"mutation{field1}"}', request.toString());
-        System.assertEquals('{\n  "query" : "mutation {\\n  field1\\n}"\n}', request.toString(true));
+        Assert.areEqual(GraphQLOperationType.Mutation, request.operation);
+        Assert.areEqual('{"query":"mutation{field1}"}', request.toString());
+        Assert.areEqual('{\n  "query" : "mutation {\\n  field1\\n}"\n}', request.toString(true));
     }
 
     /**
@@ -190,11 +190,10 @@ private class GraphQLMutationTest {
             .withField(fields.get(0))
             .withField(fields.get(1));
 
-        System.assert(mutation != null);
-        System.assert(String.isBlank(mutation.name));
-        System.assertEquals(nodes.size() + fields.size(), mutation.nodes.size());
-        System.assertEquals('mutation{field1,field2,field3,field4}', mutation.build());
-        System.assertEquals('mutation {\n  field1\n  field2\n  field3\n  field4\n}', mutation.build(true));
+        Assert.isTrue(String.isBlank(mutation.name));
+        Assert.areEqual(nodes.size() + fields.size(), mutation.nodes.size());
+        Assert.areEqual('mutation{field1,field2,field3,field4}', mutation.build());
+        Assert.areEqual('mutation {\n  field1\n  field2\n  field3\n  field4\n}', mutation.build(true));
     }
 
     @IsTest
@@ -207,11 +206,10 @@ private class GraphQLMutationTest {
             .withFields(fields)
             .defineVariable(new GraphQLVariable('model', 'InputType!').withDefault('hello world!'));
 
-        System.assert(mutation != null);
-        System.assert(String.isBlank(mutation.name));
-        System.assertEquals(nodes.size() + fields.size(), mutation.nodes.size());
-        System.assertEquals('mutation($model:InputType!="hello world!"){node1,node2,field3,field4}', mutation.build());
-        System.assertEquals(
+        Assert.isTrue(String.isBlank(mutation.name));
+        Assert.areEqual(nodes.size() + fields.size(), mutation.nodes.size());
+        Assert.areEqual('mutation($model:InputType!="hello world!"){node1,node2,field3,field4}', mutation.build());
+        Assert.areEqual(
             'mutation ($model: InputType! = "hello world!") {\n  node1\n  node2\n  field3\n  field4\n}',
             mutation.build(true)
         );
@@ -230,11 +228,10 @@ private class GraphQLMutationTest {
 
         GraphQLMutation mutation = new GraphQLMutation('TestMutation', nodes);
 
-        System.assert(mutation != null);
-        System.assertEquals('TestMutation', mutation.name);
-        System.assertEquals(nodes.size(), mutation.nodes.size());
-        System.assertEquals('mutation TestMutation{field1,field2{field21,field22},field3}', mutation.build());
-        System.assertEquals(
+        Assert.areEqual('TestMutation', mutation.name);
+        Assert.areEqual(nodes.size(), mutation.nodes.size());
+        Assert.areEqual('mutation TestMutation{field1,field2{field21,field22},field3}', mutation.build());
+        Assert.areEqual(
             'mutation TestMutation {\n  field1\n  field2 {\n    field21\n    field22\n  }\n  field3\n}',
             mutation.build(true)
         );

--- a/src/test/classes/GraphQLQueryTest.cls
+++ b/src/test/classes/GraphQLQueryTest.cls
@@ -4,8 +4,8 @@ private class GraphQLQueryTest {
     private static void emptyQueryTest() {
         GraphQLQuery node = new GraphQLQuery();
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(0, node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(0, node.nodes.size());
     }
 
     @IsTest
@@ -14,8 +14,8 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery(nodeName);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(0, node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(0, node.nodes.size());
     }
 
     @IsTest
@@ -24,8 +24,8 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery(childNode);
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(1, node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(1, node.nodes.size());
     }
 
     @IsTest
@@ -34,8 +34,8 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery(childNodes);
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(childNodes.size(), node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(childNodes.size(), node.nodes.size());
     }
 
     @IsTest
@@ -44,8 +44,8 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery(nodeName, new GraphQLField('node1'));
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(1, node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(1, node.nodes.size());
     }
 
     @IsTest
@@ -55,8 +55,8 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery(nodeName, childNodes);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(childNodes.size(), node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(childNodes.size(), node.nodes.size());
     }
 
     @IsTest
@@ -65,8 +65,8 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery(fields);
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(fields.size(), node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(fields.size(), node.nodes.size());
     }
 
     @IsTest
@@ -76,8 +76,8 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery(nodeName, fields);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(fields.size(), node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(fields.size(), node.nodes.size());
     }
 
     @IsTest
@@ -86,8 +86,8 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery().withField(fieldName);
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals(fieldName, node.nodes.get(0).name);
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual(fieldName, node.nodes.get(0).name);
     }
 
     @IsTest
@@ -96,9 +96,9 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery().withFields(fields);
 
-        System.assertEquals(fields.size(), node.nodes.size());
-        System.assertEquals('field1', node.nodes.get(0).name);
-        System.assertEquals('field2', node.nodes.get(1).name);
+        Assert.areEqual(fields.size(), node.nodes.size());
+        Assert.areEqual('field1', node.nodes.get(0).name);
+        Assert.areEqual('field2', node.nodes.get(1).name);
     }
 
     @IsTest
@@ -107,9 +107,9 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery().defineFragment(fragment);
 
-        System.assert(node.hasFragments());
-        System.assertEquals(1, node.fragments.size());
-        System.assertEquals(fragment.name, node.fragments.get(0).name);
+        Assert.isTrue(node.hasFragments());
+        Assert.areEqual(1, node.fragments.size());
+        Assert.areEqual(fragment.name, node.fragments.get(0).name);
     }
 
     @IsTest
@@ -121,19 +121,19 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery().defineFragments(fragments);
 
-        System.assert(node.hasFragments());
-        System.assertEquals(fragments.size(), node.fragments.size());
-        System.assertEquals('fragment1', node.fragments.get(0).name);
-        System.assertEquals('fragment2', node.fragments.get(1).name);
+        Assert.isTrue(node.hasFragments());
+        Assert.areEqual(fragments.size(), node.fragments.size());
+        Assert.areEqual('fragment1', node.fragments.get(0).name);
+        Assert.areEqual('fragment2', node.fragments.get(1).name);
     }
 
     @IsTest
     private static void queryWithDirectiveTest() {
         GraphQLQuery query = new GraphQLQuery().withDirective(new GraphQLDirective('test')).withField('field');
 
-        System.assertEquals(1, query.directives.size());
-        System.assertEquals('query@test{field}', query.build());
-        System.assertEquals('query @test {\n  field\n}', query.build(true));
+        Assert.areEqual(1, query.directives.size());
+        Assert.areEqual('query@test{field}', query.build());
+        Assert.areEqual('query @test {\n  field\n}', query.build(true));
     }
 
     @IsTest
@@ -147,8 +147,8 @@ private class GraphQLQueryTest {
             error = ex;
         }
 
-        System.assert(error != null);
-        System.assert(error instanceof GraphQLOperation.GraphQLOperationException);
+        Assert.isNotNull(error);
+        Assert.isInstanceOfType(error, GraphQLOperation.GraphQLOperationException.class);
     }
 
     @IsTest
@@ -157,8 +157,8 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery().withField(new GraphQLField(nodeName));
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals(nodeName, node.nodes.get(0).name);
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual(nodeName, node.nodes.get(0).name);
     }
 
     @IsTest
@@ -167,9 +167,9 @@ private class GraphQLQueryTest {
 
         GraphQLQuery node = new GraphQLQuery().withFields(nodes);
 
-        System.assertEquals(nodes.size(), node.nodes.size());
-        System.assertEquals('node1', node.nodes.get(0).name);
-        System.assertEquals('node2', node.nodes.get(1).name);
+        Assert.areEqual(nodes.size(), node.nodes.size());
+        Assert.areEqual('node1', node.nodes.get(0).name);
+        Assert.areEqual('node2', node.nodes.get(1).name);
     }
 
     @IsTest
@@ -178,16 +178,16 @@ private class GraphQLQueryTest {
             .withField(new GraphQLField('node'))
             .defineVariable('newVariable', '[Int]! = 0');
 
-        System.assertEquals(1, node.variables.size());
+        Assert.areEqual(1, node.variables.size());
     }
 
     @IsTest
     private static void queryBuildRequestTest() {
         GraphQLRequest request = new GraphQLQuery(new List<String> { 'field1' }).asRequest();
 
-        System.assertEquals(GraphQLOperationType.Query, request.operation);
-        System.assertEquals('{"query":"query{field1}"}', request.toString());
-        System.assertEquals('{\n  "query" : "query {\\n  field1\\n}"\n}', request.toString(true));
+        Assert.areEqual(GraphQLOperationType.Query, request.operation);
+        Assert.areEqual('{"query":"query{field1}"}', request.toString());
+        Assert.areEqual('{\n  "query" : "query {\\n  field1\\n}"\n}', request.toString(true));
     }
 
     /**
@@ -205,11 +205,10 @@ private class GraphQLQueryTest {
             .withFields(fields)
             .withField('field3');
 
-        System.assert(query != null);
-        System.assert(String.isBlank(query.name));
-        System.assertEquals(nodes.size() + fields.size(), query.nodes.size());
-        System.assertEquals('query{field1,field2,field3,field4}', query.build());
-        System.assertEquals('query {\n  field1\n  field2\n  field3\n  field4\n}', query.build(true));
+        Assert.isTrue(String.isBlank(query.name));
+        Assert.areEqual(nodes.size() + fields.size(), query.nodes.size());
+        Assert.areEqual('query{field1,field2,field3,field4}', query.build());
+        Assert.areEqual('query {\n  field1\n  field2\n  field3\n  field4\n}', query.build(true));
     }
 
     @IsTest
@@ -223,11 +222,10 @@ private class GraphQLQueryTest {
             .withFields(fields)
             .withField('field3');
 
-        System.assert(query != null);
-        System.assert(String.isBlank(query.name));
-        System.assertEquals(nodes.size() + fields.size(), query.nodes.size());
-        System.assertEquals('query{field1,field2,field3,field4}', query.build());
-        System.assertEquals('query {\n  field1\n  field2\n  field3\n  field4\n}', query.build(true));
+        Assert.isTrue(String.isBlank(query.name));
+        Assert.areEqual(nodes.size() + fields.size(), query.nodes.size());
+        Assert.areEqual('query{field1,field2,field3,field4}', query.build());
+        Assert.areEqual('query {\n  field1\n  field2\n  field3\n  field4\n}', query.build(true));
     }
 
     @IsTest
@@ -244,14 +242,10 @@ private class GraphQLQueryTest {
             .defineVariable(new GraphQLVariable('param1', 'Int').asNonNull())
             .defineVariable('param2', 'String');
 
-        System.assert(query != null);
-        System.assert(String.isBlank(query.name));
-        System.assertEquals(nodes.size() + fields.size(), query.nodes.size());
-        System.assertEquals(
-            'query($param1:Int!,$param2:String){node1(arg:$param1),node2,field3,field4}',
-            query.build()
-        );
-        System.assertEquals(
+        Assert.isTrue(String.isBlank(query.name));
+        Assert.areEqual(nodes.size() + fields.size(), query.nodes.size());
+        Assert.areEqual('query($param1:Int!,$param2:String){node1(arg:$param1),node2,field3,field4}', query.build());
+        Assert.areEqual(
             'query ($param1: Int!, $param2: String) {\n  node1(arg: $param1)\n  node2\n  field3\n  field4\n}',
             query.build(true)
         );
@@ -270,11 +264,10 @@ private class GraphQLQueryTest {
 
         GraphQLQuery query = new GraphQLQuery('TestQuery', nodes).withField('field1');
 
-        System.assert(query != null);
-        System.assertEquals('TestQuery', query.name);
-        System.assertEquals(nodes.size(), query.nodes.size());
-        System.assertEquals('query TestQuery{field1,field2{field21,field22},field3}', query.build());
-        System.assertEquals(
+        Assert.areEqual('TestQuery', query.name);
+        Assert.areEqual(nodes.size(), query.nodes.size());
+        Assert.areEqual('query TestQuery{field1,field2{field21,field22},field3}', query.build());
+        Assert.areEqual(
             'query TestQuery {\n  field1\n  field2 {\n    field21\n    field22\n  }\n  field3\n}',
             query.build(true)
         );
@@ -293,13 +286,13 @@ private class GraphQLQueryTest {
 
         GraphQLQuery query = new GraphQLQuery().withFields(nodes).defineFragments(fragments);
 
-        System.assertEquals(
+        Assert.areEqual(
             'query{node1{...Fields1},node2{...Fields2}}' +
                 'fragment Fields1 on Type1{f1,f2}' +
                 'fragment Fields2 on Type2{f3,f4}',
             query.build()
         );
-        System.assertEquals(
+        Assert.areEqual(
             'query {\n  node1 {\n    ...Fields1\n  }\n  node2 {\n    ...Fields2\n  }\n}\n' +
                 'fragment Fields1 on Type1 {\n  f1\n  f2\n}\n' +
                 'fragment Fields2 on Type2 {\n  f3\n  f4\n}',

--- a/src/test/classes/GraphQLRequestTest.cls
+++ b/src/test/classes/GraphQLRequestTest.cls
@@ -6,10 +6,10 @@ private class GraphQLRequestTest {
 
         GraphQLRequest request = new GraphQLRequest(stringNode);
 
-        System.assertEquals(GraphQLRequest.DEFAULT_REQUEST_TIMEOUT, request.timeout);
-        System.assertEquals(GraphQLOperationType.Query, request.operation);
-        System.assertEquals('{"query":"query{field1, field2}"}', request.toString());
-        System.assertEquals('{\n  "query" : "query{field1, field2}"\n}', request.toString(true));
+        Assert.areEqual(GraphQLRequest.DEFAULT_REQUEST_TIMEOUT, request.timeout);
+        Assert.areEqual(GraphQLOperationType.Query, request.operation);
+        Assert.areEqual('{"query":"query{field1, field2}"}', request.toString());
+        Assert.areEqual('{\n  "query" : "query{field1, field2}"\n}', request.toString(true));
     }
 
     @IsTest
@@ -18,9 +18,9 @@ private class GraphQLRequestTest {
 
         GraphQLRequest request = new GraphQLRequest(stringNode);
 
-        System.assertEquals(GraphQLOperationType.Mutation, request.operation);
-        System.assertEquals('{"query":"mutation{field1, field2}"}', request.toString());
-        System.assertEquals('{\n  "query" : "mutation{field1, field2}"\n}', request.toString(true));
+        Assert.areEqual(GraphQLOperationType.Mutation, request.operation);
+        Assert.areEqual('{"query":"mutation{field1, field2}"}', request.toString());
+        Assert.areEqual('{\n  "query" : "mutation{field1, field2}"\n}', request.toString(true));
     }
 
     @IsTest
@@ -32,8 +32,8 @@ private class GraphQLRequestTest {
             error = ex;
         }
 
-        System.assert(error != null);
-        System.assertEquals('The provided string node is empty or in invalid format', error.getMessage());
+        Assert.isNotNull(error);
+        Assert.areEqual('The provided string node is empty or in invalid format', error.getMessage());
     }
 
     @IsTest
@@ -46,8 +46,8 @@ private class GraphQLRequestTest {
             error = ex;
         }
 
-        System.assert(error != null);
-        System.assertEquals('This operation is not allowed for GraphQL request', error.getMessage());
+        Assert.isNotNull(error);
+        Assert.areEqual('This operation is not allowed for GraphQL request', error.getMessage());
     }
 
     @IsTest
@@ -56,9 +56,9 @@ private class GraphQLRequestTest {
 
         GraphQLRequest request = new GraphQLRequest(node);
 
-        System.assertEquals(GraphQLOperationType.Query, request.operation);
-        System.assertEquals('{"query":"query{field1,field2}"}', request.toString());
-        System.assertEquals('{\n  "query" : "query {\\n  field1\\n  field2\\n}"\n}', request.toString(true));
+        Assert.areEqual(GraphQLOperationType.Query, request.operation);
+        Assert.areEqual('{"query":"query{field1,field2}"}', request.toString());
+        Assert.areEqual('{\n  "query" : "query {\\n  field1\\n  field2\\n}"\n}', request.toString(true));
     }
 
     @IsTest
@@ -70,8 +70,8 @@ private class GraphQLRequestTest {
             error = err;
         }
 
-        System.assert(error != null);
-        System.assertEquals('The request node should be an either a Query or Mutation node', error.getMessage());
+        Assert.isNotNull(error);
+        Assert.areEqual('The request node should be an either a Query or Mutation node', error.getMessage());
     }
 
     @IsTest
@@ -80,9 +80,9 @@ private class GraphQLRequestTest {
 
         GraphQLRequest request = new GraphQLRequest(node);
 
-        System.assertEquals(GraphQLOperationType.Mutation, request.operation);
-        System.assertEquals('{"query":"mutation{field1,field2}"}', request.toString());
-        System.assertEquals('{\n  "query" : "mutation {\\n  field1\\n  field2\\n}"\n}', request.toString(true));
+        Assert.areEqual(GraphQLOperationType.Mutation, request.operation);
+        Assert.areEqual('{"query":"mutation{field1,field2}"}', request.toString());
+        Assert.areEqual('{\n  "query" : "mutation {\\n  field1\\n  field2\\n}"\n}', request.toString(true));
     }
 
     @IsTest
@@ -92,8 +92,8 @@ private class GraphQLRequestTest {
 
         GraphQLRequest request = new GraphQLRequest(node).withHeader('Authorization', 'token');
 
-        System.assertEquals(1, request.headers.size());
-        System.assertEquals('token', request.headers.get('Authorization'));
+        Assert.areEqual(1, request.headers.size());
+        Assert.areEqual('token', request.headers.get('Authorization'));
     }
 
     @IsTest
@@ -103,7 +103,7 @@ private class GraphQLRequestTest {
 
         GraphQLRequest request = new GraphQLRequest(node).withTimeout(10000);
 
-        System.assertEquals(10000, request.timeout);
+        Assert.areEqual(10000, request.timeout);
     }
 
     @IsTest
@@ -113,6 +113,6 @@ private class GraphQLRequestTest {
 
         GraphQLRequest request = new GraphQLRequest(node).withVariable('param', 'value');
 
-        System.assertEquals('{"variables":{"param":"value"},"query":"mutation{field1,field2}"}', request.toString());
+        Assert.areEqual('{"variables":{"param":"value"},"query":"mutation{field1,field2}"}', request.toString());
     }
 }

--- a/src/test/classes/GraphQLResponseTest.cls
+++ b/src/test/classes/GraphQLResponseTest.cls
@@ -5,39 +5,39 @@ private class GraphQLResponseTest {
         String message = 'Error!';
         GraphQLResponseError error = new GraphQLResponseError(message);
         GraphQLResponse response = new GraphQLResponse(error);
-        System.assert(response.hasErrors());
-        System.assert(!response.hasData());
+        Assert.isTrue(response.hasErrors());
+        Assert.isFalse(response.hasData());
         List<GraphQLResponseError> responseErrors = response.getErrors();
-        System.assertEquals(1, responseErrors.size());
-        System.assertEquals(message, responseErrors.get(0).message);
-        System.assert(responseErrors.get(0).locations == null);
-        System.assert(responseErrors.get(0).path == null);
-        System.assert(responseErrors.get(0).extensions == null);
+        Assert.areEqual(1, responseErrors.size());
+        Assert.areEqual(message, responseErrors.get(0).message);
+        Assert.isNull(responseErrors.get(0).locations);
+        Assert.isNull(responseErrors.get(0).path);
+        Assert.isNull(responseErrors.get(0).extensions);
     }
 
     @IsTest
     private static void parseFromResponseJsonTest() {
         GraphQLResponse response = prepareErrorResponse();
-        System.assert(response.hasErrors());
-        System.assert(response.hasData());
+        Assert.isTrue(response.hasErrors());
+        Assert.isTrue(response.hasData());
         Map<String, Object> responseData = response.getData();
         Map<String, Object> hero = (Map<String, Object>) response.getDataNode('hero');
         List<GraphQLResponseError> responseErrors = response.getErrors();
-        System.assertEquals(1, responseErrors.size());
-        System.assert(String.isNotBlank(responseErrors.get(0).message));
-        System.assertEquals(1, responseErrors.get(0).locations.size());
-        System.assertEquals(6, responseErrors.get(0).locations.get(0).line);
-        System.assertEquals(7, responseErrors.get(0).locations.get(0).column);
-        System.assertEquals(4, responseErrors.get(0).path.size());
-        System.assertEquals('hero', responseErrors.get(0).path.get(0));
-        System.assertEquals('heroFriends', responseErrors.get(0).path.get(1));
-        System.assertEquals(1, (Integer) responseErrors.get(0).path.get(2));
-        System.assertEquals('name', responseErrors.get(0).path.get(3));
-        System.assertEquals(2, responseErrors.get(0).extensions.size());
-        System.assertEquals(200, (Integer) responseErrors.get(0).extensions.get('code'));
-        System.assertEquals('Test!', responseErrors.get(0).extensions.get('customField'));
-        System.assert(responseData.containsKey('hero'));
-        System.assertEquals('R2-D2', (String) hero.get('name'));
+        Assert.areEqual(1, responseErrors.size());
+        Assert.isTrue(String.isNotBlank(responseErrors.get(0).message));
+        Assert.areEqual(1, responseErrors.get(0).locations.size());
+        Assert.areEqual(6, responseErrors.get(0).locations.get(0).line);
+        Assert.areEqual(7, responseErrors.get(0).locations.get(0).column);
+        Assert.areEqual(4, responseErrors.get(0).path.size());
+        Assert.areEqual('hero', responseErrors.get(0).path.get(0));
+        Assert.areEqual('heroFriends', responseErrors.get(0).path.get(1));
+        Assert.areEqual(1, (Integer) responseErrors.get(0).path.get(2));
+        Assert.areEqual('name', responseErrors.get(0).path.get(3));
+        Assert.areEqual(2, responseErrors.get(0).extensions.size());
+        Assert.areEqual(200, (Integer) responseErrors.get(0).extensions.get('code'));
+        Assert.areEqual('Test!', responseErrors.get(0).extensions.get('customField'));
+        Assert.isTrue(responseData.containsKey('hero'));
+        Assert.areEqual('R2-D2', (String) hero.get('name'));
     }
 
     @IsTest
@@ -46,34 +46,34 @@ private class GraphQLResponseTest {
         GraphQLResponseError firstError = errors.get(0);
         ErrorExtensionsWrapper extensions = (ErrorExtensionsWrapper) firstError
             .getExtensionsAs(ErrorExtensionsWrapper.class);
-        System.assert(extensions != null);
-        System.assertEquals(200, extensions.code);
-        System.assertEquals('Test!', extensions.customField);
+        Assert.isNotNull(extensions);
+        Assert.areEqual(200, extensions.code);
+        Assert.areEqual('Test!', extensions.customField);
     }
 
     @IsTest
     private static void getDataAsTypeTest() {
         GraphQLResponse response = prepareNoErrorsResponse();
         DataWrapper responseData = (DataWrapper) response.getDataAs(DataWrapper.class);
-        System.assert(response.hasData());
-        System.assert(!response.hasErrors());
-        System.assertEquals(0, response.getErrors().size());
-        System.assert(responseData.hero != null);
-        System.assertEquals(null, responseData.hero.id);
-        System.assertEquals('R2-D2', responseData.hero.name);
-        System.assertEquals(2, responseData.hero.heroFriends.size());
+        Assert.isTrue(response.hasData());
+        Assert.isFalse(response.hasErrors());
+        Assert.areEqual(0, response.getErrors().size());
+        Assert.isNotNull(responseData.hero);
+        Assert.isNull(responseData.hero.id);
+        Assert.areEqual('R2-D2', responseData.hero.name);
+        Assert.areEqual(2, responseData.hero.heroFriends.size());
     }
 
     @IsTest
     private static void getDataNodeAsTypeTest() {
         GraphQLResponse response = prepareNoErrorsResponse();
         HeroWrapper hero = (HeroWrapper) response.getDataNodeAs('hero', HeroWrapper.class);
-        System.assert(response.hasData());
-        System.assert(!response.hasErrors());
-        System.assert(hero != null);
-        System.assertEquals(null, hero.id);
-        System.assertEquals('R2-D2', hero.name);
-        System.assertEquals(2, hero.heroFriends.size());
+        Assert.isTrue(response.hasData());
+        Assert.isFalse(response.hasErrors());
+        Assert.isNotNull(hero);
+        Assert.isNull(hero.id);
+        Assert.areEqual('R2-D2', hero.name);
+        Assert.areEqual(2, hero.heroFriends.size());
     }
 
     private static GraphQLResponse prepareNoErrorsResponse() {

--- a/src/test/classes/GraphQLSubscriptionTest.cls
+++ b/src/test/classes/GraphQLSubscriptionTest.cls
@@ -4,8 +4,8 @@ private class GraphQLSubscriptionTest {
     private static void emptySubscriptionTest() {
         GraphQLSubscription node = new GraphQLSubscription();
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(0, node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(0, node.nodes.size());
     }
 
     @IsTest
@@ -14,8 +14,8 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription(nodeName);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(0, node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(0, node.nodes.size());
     }
 
     @IsTest
@@ -24,8 +24,8 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription(childNode);
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(1, node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(1, node.nodes.size());
     }
 
     @IsTest
@@ -34,8 +34,8 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription(childNodes);
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(childNodes.size(), node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(childNodes.size(), node.nodes.size());
     }
 
     @IsTest
@@ -44,8 +44,8 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription(nodeName, new GraphQLField('node1'));
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(1, node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(1, node.nodes.size());
     }
 
     @IsTest
@@ -55,8 +55,8 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription(nodeName, childNodes);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(childNodes.size(), node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(childNodes.size(), node.nodes.size());
     }
 
     @IsTest
@@ -65,8 +65,8 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription(fields);
 
-        System.assert(String.isBlank(node.name));
-        System.assertEquals(fields.size(), node.nodes.size());
+        Assert.isTrue(String.isBlank(node.name));
+        Assert.areEqual(fields.size(), node.nodes.size());
     }
 
     @IsTest
@@ -76,8 +76,8 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription(nodeName, fields);
 
-        System.assertEquals(nodeName, node.name);
-        System.assertEquals(fields.size(), node.nodes.size());
+        Assert.areEqual(nodeName, node.name);
+        Assert.areEqual(fields.size(), node.nodes.size());
     }
 
     @IsTest
@@ -86,8 +86,8 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription().withField(fieldName);
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals(fieldName, node.nodes.get(0).name);
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual(fieldName, node.nodes.get(0).name);
     }
 
     @IsTest
@@ -96,9 +96,9 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription().withFields(fields);
 
-        System.assertEquals(fields.size(), node.nodes.size());
-        System.assertEquals('field1', node.nodes.get(0).name);
-        System.assertEquals('field2', node.nodes.get(1).name);
+        Assert.areEqual(fields.size(), node.nodes.size());
+        Assert.areEqual('field1', node.nodes.get(0).name);
+        Assert.areEqual('field2', node.nodes.get(1).name);
     }
 
     @IsTest
@@ -107,9 +107,9 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription().defineFragment(fragment);
 
-        System.assert(node.hasFragments());
-        System.assertEquals(1, node.fragments.size());
-        System.assertEquals(fragment.name, node.fragments.get(0).name);
+        Assert.isTrue(node.hasFragments());
+        Assert.areEqual(1, node.fragments.size());
+        Assert.areEqual(fragment.name, node.fragments.get(0).name);
     }
 
     @IsTest
@@ -121,10 +121,10 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription().defineFragments(fragments);
 
-        System.assert(node.hasFragments());
-        System.assertEquals(fragments.size(), node.fragments.size());
-        System.assertEquals('fragment1', node.fragments.get(0).name);
-        System.assertEquals('fragment2', node.fragments.get(1).name);
+        Assert.isTrue(node.hasFragments());
+        Assert.areEqual(fragments.size(), node.fragments.size());
+        Assert.areEqual('fragment1', node.fragments.get(0).name);
+        Assert.areEqual('fragment2', node.fragments.get(1).name);
     }
 
     @IsTest
@@ -133,9 +133,9 @@ private class GraphQLSubscriptionTest {
             .withDirective(new GraphQLDirective('test'))
             .withField('field');
 
-        System.assertEquals(1, subscription.directives.size());
-        System.assertEquals('subscription@test{field}', subscription.build());
-        System.assertEquals('subscription @test {\n  field\n}', subscription.build(true));
+        Assert.areEqual(1, subscription.directives.size());
+        Assert.areEqual('subscription@test{field}', subscription.build());
+        Assert.areEqual('subscription @test {\n  field\n}', subscription.build(true));
     }
 
     @IsTest
@@ -144,8 +144,8 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription().withField(new GraphQLField(nodeName));
 
-        System.assertEquals(1, node.nodes.size());
-        System.assertEquals(nodeName, node.nodes.get(0).name);
+        Assert.areEqual(1, node.nodes.size());
+        Assert.areEqual(nodeName, node.nodes.get(0).name);
     }
 
     @IsTest
@@ -154,9 +154,9 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription node = new GraphQLSubscription().withFields(nodes);
 
-        System.assertEquals(nodes.size(), node.nodes.size());
-        System.assertEquals('node1', node.nodes.get(0).name);
-        System.assertEquals('node2', node.nodes.get(1).name);
+        Assert.areEqual(nodes.size(), node.nodes.size());
+        Assert.areEqual('node1', node.nodes.get(0).name);
+        Assert.areEqual('node2', node.nodes.get(1).name);
     }
 
     @IsTest
@@ -165,7 +165,7 @@ private class GraphQLSubscriptionTest {
             .withField(new GraphQLField('node'))
             .defineVariable('newVariable', '[Int]! = 0');
 
-        System.assertEquals(1, node.variables.size());
+        Assert.areEqual(1, node.variables.size());
     }
 
     @IsTest
@@ -177,8 +177,8 @@ private class GraphQLSubscriptionTest {
             error = ex;
         }
 
-        System.assert(error != null);
-        System.assert(error instanceof GraphQLOperation.GraphQLOperationException);
+        Assert.isNotNull(error);
+        Assert.isInstanceOfType(error, GraphQLOperation.GraphQLOperationException.class);
     }
 
     /**
@@ -196,11 +196,10 @@ private class GraphQLSubscriptionTest {
             .withFields(fields)
             .withField('field3');
 
-        System.assert(subscription != null);
-        System.assert(String.isBlank(subscription.name));
-        System.assertEquals(nodes.size() + fields.size(), subscription.nodes.size());
-        System.assertEquals('subscription{field1,field2,field3,field4}', subscription.build());
-        System.assertEquals('subscription {\n  field1\n  field2\n  field3\n  field4\n}', subscription.build(true));
+        Assert.isTrue(String.isBlank(subscription.name));
+        Assert.areEqual(nodes.size() + fields.size(), subscription.nodes.size());
+        Assert.areEqual('subscription{field1,field2,field3,field4}', subscription.build());
+        Assert.areEqual('subscription {\n  field1\n  field2\n  field3\n  field4\n}', subscription.build(true));
     }
 
     @IsTest
@@ -217,14 +216,13 @@ private class GraphQLSubscriptionTest {
             .defineVariable('param1', 'Int!')
             .defineVariable('param2', 'String');
 
-        System.assert(subscription != null);
-        System.assert(String.isBlank(subscription.name));
-        System.assertEquals(nodes.size() + fields.size(), subscription.nodes.size());
-        System.assertEquals(
+        Assert.isTrue(String.isBlank(subscription.name));
+        Assert.areEqual(nodes.size() + fields.size(), subscription.nodes.size());
+        Assert.areEqual(
             'subscription($param1:Int!,$param2:String){node1(arg:$param1),node2,field3,field4}',
             subscription.build()
         );
-        System.assertEquals(
+        Assert.areEqual(
             'subscription ($param1: Int!, $param2: String) {\n  node1(arg: $param1)\n  node2\n  field3\n  field4\n}',
             subscription.build(true)
         );
@@ -243,14 +241,10 @@ private class GraphQLSubscriptionTest {
 
         GraphQLSubscription subscription = new GraphQLSubscription('TestSubscription', nodes).withField('field1');
 
-        System.assert(Subscription != null);
-        System.assertEquals('TestSubscription', subscription.name);
-        System.assertEquals(nodes.size(), subscription.nodes.size());
-        System.assertEquals(
-            'subscription TestSubscription{field1,field2{field21,field22},field3}',
-            subscription.build()
-        );
-        System.assertEquals(
+        Assert.areEqual('TestSubscription', subscription.name);
+        Assert.areEqual(nodes.size(), subscription.nodes.size());
+        Assert.areEqual('subscription TestSubscription{field1,field2{field21,field22},field3}', subscription.build());
+        Assert.areEqual(
             'subscription TestSubscription {\n  field1\n  field2 {\n    field21\n    field22\n  }\n  field3\n}',
             subscription.build(true)
         );

--- a/src/test/classes/GraphQLVariableTest.cls
+++ b/src/test/classes/GraphQLVariableTest.cls
@@ -4,60 +4,60 @@ private class GraphQLVariableTest {
     private static void createVariableTest() {
         GraphQLVariable variable = new GraphQLVariable('key', 'Int');
 
-        System.assertEquals('key', variable.name);
-        System.assertEquals('Int', variable.type);
-        System.assertEquals(null, variable.defaultValue);
-        System.assert(!variable.isNonNull);
-        System.assertEquals('$key:Int', variable.toString());
-        System.assertEquals('$key: Int', variable.toString(true));
+        Assert.areEqual('key', variable.name);
+        Assert.areEqual('Int', variable.type);
+        Assert.isNull(variable.defaultValue);
+        Assert.isFalse(variable.isNonNull);
+        Assert.areEqual('$key:Int', variable.toString());
+        Assert.areEqual('$key: Int', variable.toString(true));
     }
 
     @IsTest
     private static void createVariableAsNonNullTest() {
         GraphQLVariable variable = new GraphQLVariable('key', 'Int').asNonNull();
 
-        System.assertEquals('key', variable.name);
-        System.assertEquals('Int', variable.type);
-        System.assertEquals(null, variable.defaultValue);
-        System.assert(variable.isNonNull);
-        System.assertEquals('$key:Int!', variable.toString());
-        System.assertEquals('$key: Int!', variable.toString(true));
+        Assert.areEqual('key', variable.name);
+        Assert.areEqual('Int', variable.type);
+        Assert.isNull(variable.defaultValue);
+        Assert.isTrue(variable.isNonNull);
+        Assert.areEqual('$key:Int!', variable.toString());
+        Assert.areEqual('$key: Int!', variable.toString(true));
     }
 
     @IsTest
     private static void createNonNullVariableTest() {
         GraphQLVariable variable = new GraphQLVariable('key', 'Int!');
 
-        System.assertEquals('key', variable.name);
-        System.assertEquals('Int', variable.type);
-        System.assertEquals(null, variable.defaultValue);
-        System.assert(variable.isNonNull);
-        System.assertEquals('$key:Int!', variable.toString());
-        System.assertEquals('$key: Int!', variable.toString(true));
+        Assert.areEqual('key', variable.name);
+        Assert.areEqual('Int', variable.type);
+        Assert.isNull(variable.defaultValue);
+        Assert.isTrue(variable.isNonNull);
+        Assert.areEqual('$key:Int!', variable.toString());
+        Assert.areEqual('$key: Int!', variable.toString(true));
     }
 
     @IsTest
     private static void createNonNullVariableWithDollarNameTest() {
         GraphQLVariable variable = new GraphQLVariable('$key', 'Int!');
 
-        System.assertEquals('key', variable.name);
-        System.assertEquals('Int', variable.type);
-        System.assertEquals(null, variable.defaultValue);
-        System.assert(variable.isNonNull);
-        System.assertEquals('$key:Int!', variable.toString());
-        System.assertEquals('$key: Int!', variable.toString(true));
+        Assert.areEqual('key', variable.name);
+        Assert.areEqual('Int', variable.type);
+        Assert.isNull(variable.defaultValue);
+        Assert.isTrue(variable.isNonNull);
+        Assert.areEqual('$key:Int!', variable.toString());
+        Assert.areEqual('$key: Int!', variable.toString(true));
     }
 
     @IsTest
     private static void createVariableWithDefaultStringValueTest() {
         GraphQLVariable variable = new GraphQLVariable('$key', 'String').withDefault('hello world!');
 
-        System.assertEquals('key', variable.name);
-        System.assertEquals('String', variable.type);
-        System.assertEquals('hello world!', variable.defaultValue);
-        System.assert(!variable.isNonNull);
-        System.assertEquals('$key:String="hello world!"', variable.toString());
-        System.assertEquals('$key: String = "hello world!"', variable.toString(true));
+        Assert.areEqual('key', variable.name);
+        Assert.areEqual('String', variable.type);
+        Assert.areEqual('hello world!', variable.defaultValue);
+        Assert.isTrue(!variable.isNonNull);
+        Assert.areEqual('$key:String="hello world!"', variable.toString());
+        Assert.areEqual('$key: String = "hello world!"', variable.toString(true));
     }
 
     @IsTest

--- a/src/test/classes/GraphQLVariableTest.cls
+++ b/src/test/classes/GraphQLVariableTest.cls
@@ -49,7 +49,7 @@ private class GraphQLVariableTest {
     }
 
     @IsTest
-    private static void createVariableWithWithDefaultStringValueTest() {
+    private static void createVariableWithDefaultStringValueTest() {
         GraphQLVariable variable = new GraphQLVariable('$key', 'String').withDefault('hello world!');
 
         System.assertEquals('key', variable.name);
@@ -61,27 +61,27 @@ private class GraphQLVariableTest {
     }
 
     @IsTest
-    private static void createVariableWithWithDefaultEnumValueTest() {
-        GraphQLVariable variable = new GraphQLVariable('$key', 'SomeEnum').withDefault('ENUM_VAL').asEnum();
+    private static void createVariableWithDefaultEnumValueTest() {
+        GraphQLVariable variable = new GraphQLVariable('$key', 'SomeEnum').withDefault(new GraphQLEnum('ENUM_VAL'));
 
-        System.assertEquals('key', variable.name);
-        System.assertEquals('SomeEnum', variable.type);
-        System.assertEquals('ENUM_VAL', variable.defaultValue);
-        System.assert(!variable.isNonNull);
-        System.assertEquals('$key:SomeEnum=ENUM_VAL', variable.toString());
-        System.assertEquals('$key: SomeEnum = ENUM_VAL', variable.toString(true));
+        Assert.areEqual('key', variable.name);
+        Assert.areEqual('SomeEnum', variable.type);
+        Assert.areEqual('ENUM_VAL', variable.defaultValue?.toString());
+        Assert.isFalse(variable.isNonNull);
+        Assert.areEqual('$key:SomeEnum=ENUM_VAL', variable.toString());
+        Assert.areEqual('$key: SomeEnum = ENUM_VAL', variable.toString(true));
     }
 
     @IsTest
-    private static void asEnumWithoutDefaultValueNegativeTest() {
-        Exception error;
-        try {
-            new GraphQLVariable('$key', 'SomeEnum').asEnum();
-        } catch (Exception ex) {
-            error = ex;
-        }
+    private static void createVariableWithDefaultEnumListValueTest() {
+        GraphQLVariable variable = new GraphQLVariable('$key', 'SomeEnum')
+            .withDefault(new List<GraphQLEnum> { new GraphQLEnum('ENUM_VAL1'), new GraphQLEnum('ENUM_VAL2') });
 
-        System.assert(error != null);
-        System.assert(error instanceof GraphQLVariable.GraphQLVariableException);
+        Assert.areEqual('key', variable.name);
+        Assert.areEqual('SomeEnum', variable.type);
+        Assert.isInstanceOfType(variable.defaultValue, List<Object>.class);
+        Assert.isFalse(variable.isNonNull);
+        Assert.areEqual('$key:SomeEnum=[ENUM_VAL1,ENUM_VAL2]', variable.toString());
+        Assert.areEqual('$key: SomeEnum = [ ENUM_VAL1, ENUM_VAL2 ]', variable.toString(true));
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR provides a better way of using enums for arguments and variable default values.

### What issues does this PR fix or reference?

[The issue](https://github.com/IlyaMatsuev/Apex-GraphQL-Client/issues/29)

## The PR fulfills these requirements:

-   [x] Tests for the proposed changes have been added/updated.
-   [x] The documentation has been updated according to the introduced/changed components.
-   [x] ApexDoc comments have been attached to all `global` classes, fields, properties and methods.

### Functionality Before

```gql
{
    countryByCode(code: CODE_NL) {
        name
    }
}
```

```java
GraphQLField countryByCode = new GraphQLField('countryByCode')
    .withField('name')
    .withArgument(new GraphQLArgument('code', 'CODE_NL').asEnum());     // <----

GraphQLQuery query = new GraphQLQuery(countryByCode);
System.debug(query.build(true));
```

### Functionality After

```gql
{
    countryByCode(code: CODE_NL) {
        name
    }
}
```

```java
GraphQLField countryByCode = new GraphQLField('countryByCode')
    .withField('name')
    .withArgument('code', new GraphQLEnum('CODE_NL'));     // <----

GraphQLQuery query = new GraphQLQuery(countryByCode);
System.debug(query.build(true));
```

For arrays:

```gql
{
    countriesByCodes(codes: [ CODE_NL, CODE_BG ]) {
        name
    }
}
```

```java
GraphQLField countryByCode = new GraphQLField('countriesByCodes')
    .withField('name')
    .withArgument(
        'codes',
        new List<GraphQLEnum> {
            new GraphQLEnum('CODE_NL'),     // <----
            new GraphQLEnum('CODE_BG')
    );

GraphQLQuery query = new GraphQLQuery(countryByCode);
System.debug(query.build(true));
```
