### PR TITLE
Allow enums in complex arguments (#34)

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -13,6 +13,6 @@ jobs:
       - name: 'Validate Branch Name'
         uses: deepakputhraya/action-branch-name@master
         with:
-          regex: '([a-z])+\/([a-z])+'
+          regex: '(feature|bugfix)+(-\d+)?\/([a-z-])+'
           allowed_prefixes: 'feature,fix'
           min_length: 6

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: 'Promote package version'
         run: |
-          echo "Created a new package verion with Id: ${{ env.NEW_PACKAGE_VERSION_ID }}"
+          echo "Created a new package version with Id: ${{ env.NEW_PACKAGE_VERSION_ID }}"
           sfdx package:version:promote -p ${{ env.NEW_PACKAGE_VERSION_ID }} -v ${{ env.DEVHUB_ALIAS }} -n
 
       - name: 'Delete created package version'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # IDE
 .idea/
+IlluminatedCloud/
+manifest/
 
 # Salesforce cache
 .sfdx/

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,7 +4,7 @@
             "path": "./src",
             "package": "gql-apex-client",
             "versionName": "Version 2.1",
-            "versionNumber": "2.1.0.0",
+            "versionNumber": "2.1.1.0",
             "default": true
         }
     ],

--- a/src/main/default/classes/nodes/arguments/GraphQLArgument.cls
+++ b/src/main/default/classes/nodes/arguments/GraphQLArgument.cls
@@ -2,6 +2,8 @@
  * @description Represents an entry of a GraphQL argument in a node
  */
 global class GraphQLArgument {
+    // Searches for all JSON-serialized `GraphQLEnum` instances. Needed to replace it in the output result with the actual enum value
+    private static final String REPLACE_JSON_GQL_ENUMS_REGEXP = '\\s*\\{\\s*"value"\\s*:\\s*"(\\w+)",\\s*"classType"\\s*:\\s*"GraphQLEnum"\\s*\\}';
     // Searches for all JSON property names. Needed to escape properties' double quotes
     private static final String REPLACE_JSON_PROPS_REGEXP = '"(\\w+)"\\s*:';
     // Searches for all JSON values that are strings starting from '$'. Needed to escape variables' ref double quotes
@@ -135,6 +137,11 @@ global class GraphQLArgument {
 
     private String objectToString(Object value, Boolean pretty) {
         String jsonValue = pretty ? JSON.serializePretty(value, SUPPRESS_NULLS) : JSON.serialize(value, SUPPRESS_NULLS);
+
+        jsonValue = jsonValue.replaceAll(
+            REPLACE_JSON_GQL_ENUMS_REGEXP,
+            GraphQLParser.getSmallIndent(pretty) + FIRST_REGEX_MATCH_GROUP
+        );
 
         if (pretty) {
             jsonValue = jsonValue

--- a/src/main/default/classes/nodes/arguments/GraphQLEnum.cls
+++ b/src/main/default/classes/nodes/arguments/GraphQLEnum.cls
@@ -7,12 +7,16 @@ global class GraphQLEnum {
      */
     global final String value;
 
+    // This field is required to be able to identify the `GraphQLEnum` instance when an argument is JSON-serialized
+    private final String classType;
+
     /**
      * @description Creates an instance of GraphQL enum by the provided enum value
      * @param value The enum value
      */
     global GraphQLEnum(String value) {
         this.value = value;
+        this.classType = GraphQLEnum.class.getName();
     }
 
     public override String toString() {

--- a/src/test/classes/GraphQLArgumentTest.cls
+++ b/src/test/classes/GraphQLArgumentTest.cls
@@ -200,6 +200,22 @@ private class GraphQLArgumentTest {
     }
 
     @IsTest
+    private static void stringifyEnumInObjectArgumentTest() {
+        String key = 'key';
+        Map<String, Object> value = new Map<String, Object> {
+            'key3' => new GraphQLEnum('VALUE3'),
+            'key2' => new GraphQLEnum('VALUE2'),
+            'key1' => 'value1'
+        };
+
+        GraphQLArgument argument = new GraphQLArgument(key, value);
+
+        Assert.areEqual('key:{key1:"value1",key2:VALUE2,key3:VALUE3}', argument.toString());
+        Assert.areEqual('key: { key1: "value1", key2: VALUE2, key3: VALUE3 }', argument.toString(true));
+        Assert.areEqual(argument.type, GraphQLArgumentType.x_Object);
+    }
+
+    @IsTest
     private static void stringifyStringArrayArgumentTest() {
         String key = 'key';
         List<String> value = new List<String> { 'value1', 'value2' };


### PR DESCRIPTION
### What does this PR do?

Allows using `GraphQLEnum` class instances in object arguments.

### What issues does this PR fix or reference?

The issue #34 

## The PR fulfills these requirements:

-   [x] Tests for the proposed changes have been added/updated.
-   [x] The documentation has been updated according to the introduced/changed components.
-   [x] ApexDoc comments have been attached to all `global` classes, fields, properties and methods.
